### PR TITLE
Fix 9 input/output bugs, add JSON output and CI (v1.14.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
+name: Test and Release
+
 on:
   workflow_dispatch:
+  pull_request:
   push:
+    branches:
+      - main
     tags:
       - "*"
 
@@ -8,9 +13,63 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  test:
+    name: Test and Verify
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v5
+
+      - name: Set Up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.x"
+
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install jq
+        run: |
+          if ! command -v jq > /dev/null; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+          jq --version
+          bc --version | head -1
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [[ -n "$unformatted" ]]; then
+            echo "These files are not gofmt-clean:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: go test
+        run: go test -v ./...
+
+      - name: Build binary
+        run: go build -ldflags="-s -w" -o stats .
+
+      # Layer 2: independent bc verification, reading the program's JSON via jq
+      - name: Verify with bc (verify_stats.sh)
+        run: ./verify_stats.sh
+
+      # Layer 3: independent pure-Python reimplementation, compared field by field
+      - name: Verify with Python (verify_stats.py)
+        run: ./verify_stats.py
+
+  release:
     name: GoReleaser Build
     runs-on: ubuntu-latest
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: Check out code into the Go module directory

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@ go.work.sum
 # Editor/IDE
 .idea/
 # .vscode/
+
+# Compiled binary produced by `make` or `go build -o stats`
+/stats
+
+# Python bytecode from verify_stats.py
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A robust, command-line tool written in Go to compute a comprehensive set of desc
 
 ## Overview
 
-This program takes a simple, newline-delimited list of numbers (integers or floats) and calculates key statistical properties, including measures of central tendency (mean, median, mode), measures of spread (standard deviation, variance, IQR), the shape of the distribution (skewness), plus robust measures (MAD, geometric mean) and sequence properties (autocorrelation, input order). It also identifies outliers based on the interquartile range method.
+This program takes a simple, newline-delimited list of numbers (integers or floats) and calculates key statistical properties, including measures of central tendency (mean, median, mode), measures of spread (standard deviation, variance, IQR), the shape of the distribution (skewness, kurtosis, symmetry), plus robust measures (MAD, geometric mean, trimmed mean) and sequence properties (autocorrelation, input order). It also identifies outliers using three independent methods, and can emit everything as JSON for scripting.
 
 ## Disclaimer
 
@@ -17,10 +17,12 @@ This program was vibe-coded by `Gemini 2.5` Pro and `Opus 4.5`. As such, the aut
 The calculator computes the following statistics:
 
 -   **Count**: Total number of valid data points.
+-   **Sum**: The total of all values.
 -   **Min / Max**: The minimum and maximum values in the dataset.
 -   **Mean**: The arithmetic average.
+-   **95% Confidence Interval**: The range that plausibly contains the true population mean, computed as `mean ± 1.96 × standard error`.
 -   **Median (p50)**: The 50th percentile, or the middle value of the dataset.
--   **Mode**: The value(s) that appear most frequently.
+-   **Mode**: The value(s) that appear most frequently. When no value repeats, the densest histogram bin is reported instead (see [A note on Mode](#a-note-on-mode)).
 -   **Standard Deviation**: A measure of the amount of variation or dispersion.
 -   **Variance**: The square of the standard deviation.
 -   **Quartiles (Q1, Q3)**: The 25th (p25) and 75th (p75) percentiles.
@@ -36,7 +38,7 @@ The calculator computes the following statistics:
 -   **Trendline**: A single-line Unicode trendline showing the sequence pattern of values in their original input order, using configurable bins (`-b` flag).
 -   **Trimmed Mean**: A robust measure of central tendency that removes a configurable percentage from each tail (`-t` flag). Less sensitive to outliers than the regular mean while using more data than the median.
 -   **EMA (Exponential Moving Average)**: A weighted moving average that gives more weight to recent values (`-e` flag). Unlike the simple mean, EMA is order-dependent and more responsive to new data, making it useful for detecting recent trends in time-series data.
--   **Trim Dataset**: Sort and remove a percentage from each tail of the entire dataset before computing all statistics (`-T` flag). Unlike `-t` (which only adds a trimmed mean line), `-T` changes the entire output. Tail-sensitive statistics are marked with `*`.
+-   **Trim Dataset**: Sort and remove a percentage from each tail of the entire dataset before computing all statistics (`-T` flag). Unlike `-t` (which only adds a trimmed mean line), `-T` changes the entire output — every statistic, Min and Max included, is computed on the reduced dataset.
 -   **Log Transform**: Optional natural log (ln) transform applied to all input data before computing statistics (`-l` flag). Useful for heavy-tailed data spanning several orders of magnitude (file sizes, latencies, income data). Requires all values to be positive.
 -   **Symmetry**: Detects whether the dataset is a mirror image of itself about a center value, by pairing the sorted data from both ends inward. Always computed; no flag required. This is a pairwise property that summary moments cannot capture — skewness of 0, a mean equal to the median, and equidistant min/max are consequences of symmetry, not evidence of it.
 -   **Skipped Lines**: Reports how many input lines failed to parse, so malformed input cannot silently vanish from the analysis. Only shown when the count is greater than zero; blank lines are skipped silently and never counted.
@@ -45,8 +47,20 @@ The calculator computes the following statistics:
 -   **Standard Error**: The standard error of the mean (`stddev / sqrt(n)`), which tells you how much to trust the reported mean.
 -   **Geometric Mean**: The correct average for ratios, growth rates, index values, and normalized measurements. Shown only when all values are positive; suppressed under `-l` because the arithmetic mean of log-transformed values already is the log of the geometric mean.
 -   **Autocorrelation and Input Order**: Lag-1 autocorrelation measures whether each value predicts the next, and the input-order line reports whether data arrived ascending, descending, constant, or unordered. Besides the trendline and EMA, these are the only statistics in the program sensitive to input order. Both are suppressed under `-T`.
+-   **JSON Output**: Emit every computed value as a single JSON object with the `-j` flag, for piping into `jq` or any other tool.
 
-All numeric output uses full decimal notation (no scientific notation) with trailing zeros trimmed for readability.
+All numeric output uses full decimal notation (no scientific notation) with trailing zeros trimmed for readability. The number of decimal places adapts to the magnitude of each value, so small numbers keep their significant digits rather than rounding away to `0`:
+
+```
+# 0.00004 and 0.00006 are reported as themselves, not as 0
+Min:               0.00004
+Max:               0.00006
+Mean:              0.00005
+```
+
+**Note on variance:** this program computes the **sample** variance and standard deviation (dividing by `n - 1`, Bessel's correction), which is the right choice when your numbers are a sample drawn from some larger population. If your input is an entire population rather than a sample, the reported variance and standard deviation are slightly too large, and every statistic derived from them — standard error, the confidence interval, CV, and Z-score outliers — inherits that bias. There is no flag to switch to the population form; multiply the variance by `(n-1)/n` if you need it.
+
+**Note on percentiles:** all percentiles, quartiles, and the median use linear interpolation between order statistics (`rank = p × (n - 1)`), the method known as R-7 and the default in NumPy, R, and Excel's `PERCENTILE.INC`. Other tools disagree: Excel's `PERCENTILE.EXC`, most SQL engines, and Prometheus use different definitions, so a p95 cross-checked against those will differ slightly on the same data without either being wrong.
 
 ## Installation
 
@@ -60,7 +74,7 @@ All numeric output uses full decimal notation (no scientific notation) with trai
     ```bash
     git clone https://github.com/jftuga/go-stats-calculator.git
     cd go-stats-calculator
-    go build -ldflags="-s -w" -o stats stats.go
+    go build -ldflags="-s -w" -o stats .
     ```
 
 ## Claude Code Skill
@@ -320,9 +334,11 @@ Use the `-T` flag to sort the input data, remove a percentage from each tail, an
 
 When `-T` is active:
 - A header line shows the trim percentage and the before/after counts (e.g., `31 → 25 values`).
-- Tail-sensitive statistics (percentiles, MAD, skewness, kurtosis, outliers, Z-outliers, Mod Z-outliers) are marked with `*`.
+- **Every** statistic is computed on the reduced dataset, including Min, Max, Mean, and standard deviation.
 - The Trendline, Autocorrelation, and Input Order lines are suppressed (input order is lost after sorting, so they would describe the sort, not the data).
-- A footnote explains the `*` markers.
+- A footnote repeats that all values come from the trimmed data.
+
+Earlier versions marked a subset of "tail-sensitive" statistics with `*`. That convention was removed: it implied the unmarked statistics were unaffected, which was never true — trimming changes the mean, standard deviation, and Min/Max as much as it changes the percentiles.
 
 The `-T` flag is mutually exclusive with both `-t` and `-e`.
 
@@ -348,7 +364,7 @@ The `-T` flag is mutually exclusive with both `-t` and `-e`.
 | Flag | What it does | Output effect |
 | :--- | :----------- | :------------ |
 | `-t 10` | Computes a trimmed mean and adds one line to the output | All other statistics use the full dataset |
-| `-T 10` | Removes 10% from each tail, then computes everything | All statistics use the reduced dataset; `*` markers on tail-sensitive stats |
+| `-T 10` | Removes 10% from each tail, then computes everything | All statistics use the reduced dataset, Min and Max included |
 
 ### 10. Log Transform
 
@@ -407,6 +423,52 @@ python3 -c "import math; print(math.exp(3.4))"
 
 The log-space standard deviation has a useful interpretation: it approximates the "multiplicative spread" of the data. A log-space stddev of `1.0` means the typical value is within a factor of *e* (~2.7×) of the mean.
 
+### 11. JSON Output
+
+Use the `-j` flag to emit every computed value as a single JSON object instead of formatted text. This is the recommended way to consume the program from a script: the text output is padded for human reading and its alignment is not a stable interface, while the JSON field names are.
+
+**Syntax:**
+```bash
+./stats -j <filename>
+```
+
+**Examples:**
+```bash
+# Pretty-printed JSON on stdout
+./stats -j data.txt
+
+# Extract a single value
+./stats -j data.txt | jq -r '.p95'
+
+# Combine with any other flag
+./stats -j -z 2.0 -p "10,90" data.txt | jq '{mean, p95, outliers, zScoreOutliers}'
+
+# Fail a build when a latency budget is exceeded
+[[ $(./stats -j latency.txt | jq '.p99 < 250') == "true" ]] || exit 1
+```
+
+Warnings about skipped lines still go to stderr, so stdout is always valid JSON on a successful run.
+
+**Field conventions:**
+
+| Convention | Meaning |
+| :--------- | :------ |
+| `outliers` | Always an array. Empty means the detector ran and found nothing. |
+| `zScoreOutliers`, `modZOutliers` | An array when `-z` was used, `null` when it was not. |
+| `zScoreValid`, `modZValid` | `false` when `-z` was requested but the standard deviation or MAD is zero, making the score undefined. |
+| `geoMeanValid`, `cvValid`, `ciValid`, `autocorrValid`, `modalBinValid`, `isSymmetric` | Guard flags. When one is `false`, the value it guards is `0` and carries no meaning. |
+| `inputOrder`, `trendline` | Empty strings under `-T`, where sorting destroyed the input order. |
+| `customPercentiles` | Present only when `-p` was used; keys are the requested percentiles as strings. |
+
+### 12. Version
+
+Use the `-v` flag to print the program version, project URL, and disclaimer, then exit. It is handled before any other flag is validated, so it always works.
+
+**Syntax:**
+```bash
+./stats -v
+```
+
 ## Example
 
 Given a file named `sample_data.txt` with the following content:
@@ -443,6 +505,7 @@ Max:                  38.95
 --- Measures of Central Tendency ---
 Mean:                 20.73
 Std Error:            1.9263
+95% CI (mean):        [16.9544, 24.5056]
 Geometric Mean:       19.7402
 Median (p50):         18.92
 Mode:                 15.05
@@ -465,9 +528,9 @@ Z-Outliers (Z>2):     [35.88 38.95]
 Mod Z-Outliers (Z>2): [35.88 38.95]
 
 --- Distribution ---
-Histogram:            █▄▂▆▂▂▂▁▁▁▁▁▁▁▂▂
+Histogram:            █▄▄▄▄▁▂▁▁▁▁▁▁▂▂
 Trendline:            ▁▂▁▁▂▃▁▂▄▃█▃▂▇▃
-Autocorrelation:      0.0322 (no serial dependence)
+Autocorrelation:      0.03217 (no serial dependence)
 Input Order:          unordered
 ```
 
@@ -486,9 +549,10 @@ Max:               994
 --- Measures of Central Tendency ---
 Mean:              500
 Std Error:         49.368
+95% CI (mean):     [403.2386, 596.7614]
 Geometric Mean:    342.0333
 Median (p50):      500
-Mode:              None
+Mode:              None (modal bin: 6-67.75, 4 values)
 
 --- Measures of Spread & Distribution ---
 Std Deviation:     312.2309
@@ -524,25 +588,43 @@ Mod Z-Outliers (Z>2.5): [50 52]
 
 The classic z-score misses both outliers because they inflate the mean and standard deviation used to score them — two extremes on the same tail suppress each other's z-scores, a failure mode called masking. The modified z-score is built from the median and MAD, which the outliers cannot inflate, so both are caught at the same threshold. When the two lines disagree like this, trust the modified z-scores.
 
+### A note on Mode
+
+The mode counts values that are **exactly** equal, bit for bit. That is the right definition for discrete data — HTTP status codes, dice rolls, ratings, counts — where repeats are meaningful. It is close to useless for continuous measurements: two independently measured latencies or file sizes will essentially never be equal to the last decimal place, so the mode of a continuous dataset is almost always `None`.
+
+When no value repeats, the program falls back to the **modal bin**: the densest bin of the same histogram shown lower in the output, reported with its range and count.
+
+```
+# Discrete data with real repeats
+Mode:              15.05
+
+# Continuous data with no exact repeats
+Mode:              None (modal bin: 6-67.75, 4 values)
+```
+
+The bin width depends on the `-b` flag, so the modal bin is a property of the chosen binning as much as of the data. Treat it as a hint about where values cluster, not as a precise statistic. When the data is close to uniform, the "densest" bin wins by a margin of one or two observations and means very little — check the histogram before reading anything into it.
+
 ## Understanding the Output
 
 | Statistic         | Description                                                                                                                                                                |
 | :---------------- |:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Count**         | The total number of valid numeric entries processed.                                                                                                                       |
+| **Sum**           | The total of all valid values.                                                                                                                                             |
 | **Skipped**       | The number of input lines that failed to parse. Only shown when greater than zero. Blank lines are skipped silently and never counted.                                     |
 | **Distinct**      | The number of distinct values and the percentage of the dataset that is duplicated (e.g., `28 of 31 (9.6774% duplicated)`).                                                |
 | **Min**           | The smallest number in the dataset.                                                                                                                                        |
 | **Max**           | The largest number in the dataset.                                                                                                                                         |
 | **Mean**          | The "average" value. Highly sensitive to outliers.                                                                                                                         |
 | **Std Error**     | The standard error of the mean (`stddev / sqrt(n)`). Smaller values mean the reported mean is a more reliable estimate.                                                    |
+| **95% CI (mean)** | The 95% confidence interval for the mean, computed as `mean ± 1.96 × Std Error`. Roughly: if you resampled repeatedly, about 95% of such intervals would contain the true population mean. This is the normal approximation; for small samples (n < 30) the true interval is somewhat wider, because it should use a t-distribution critical value rather than 1.96. Suppressed when n < 2 or the standard error is zero. |
 | **Geometric Mean** | The n-th root of the product of all values, computed as `exp(mean(ln x))`. The correct average for ratios, growth rates, and index values. Only shown when all values are positive; suppressed under `-l`. |
 | **Trimmed Mean**  | The mean after removing a percentage of values from each tail of the sorted dataset. Only shown when `-t` is used. More robust than the mean against outliers while using more of the data than the median. |
 | **EMA** | The exponential moving average for the given span. Only shown when `-e` is used. Unlike the simple mean, EMA is order-dependent and weights recent values more heavily. |
 | **Median (p50)**  | The middle value of the sorted dataset. Represents the "typical" value and is robust against outliers.                                                                     |
-| **Mode**          | The number(s) that occur most frequently. If no number repeats, the mode is "None".                                                                                        |
+| **Mode**          | The number(s) that occur most frequently. If no number repeats, the line reads `None` followed by the densest histogram bin and its count, e.g. `None (modal bin: 6-67.75, 4 values)`. See [A note on Mode](#a-note-on-mode). |
 | **Std Deviation** | Measures how spread out the numbers are from the mean. A low value indicates data is clustered tightly; a high value indicates data is spread out.                         |
 | **Variance**      | The square of the standard deviation.                                                                                                                                      |
-| **MAD**           | The median absolute deviation (median of `abs(x - median)`), scaled by 1.4826 so it is directly comparable to the standard deviation for normal data. A robust measure of spread that outliers cannot inflate. Marked with `*` under `-T`. |
+| **MAD**           | The median absolute deviation (median of `abs(x - median)`), scaled by 1.4826 so it is directly comparable to the standard deviation for normal data. A robust measure of spread that outliers cannot inflate. |
 | **CV**            | The ratio of the standard deviation to the mean, expressed as a percentage. CV < 15% indicates low variability, 15–30% moderate variability, and ≥ 30% high variability. Shows "N/A" when the mean is near zero, and displays a warning if the dataset contains negative values. |
 | **Quartile 1 (p25)** | The value below which 25% of the data falls.                                                                                                                            |
 | **Quartile 3 (p75)** | The value below which 75% of the data falls.                                                                                                                            |
@@ -551,49 +633,59 @@ The classic z-score misses both outliers because they inflate the mean and stand
 | **Percentile (pN)** | Custom percentiles requested via the `-p` flag. The value below which N% of the data falls.                                                                              |
 | **IQR**           | The Interquartile Range (`Q3 - Q1`). It represents the middle 50% of the data and is a robust measure of spread.                                                           |
 | **Skewness**      | A measure of asymmetry. A value near 0 is symmetrical. A positive value indicates a "right skew" (a long tail of high values). A negative value indicates a "left skew".   |
-| **Symmetry**      | Reports whether the dataset is a mirror image of itself about a center value, checked by pairing the sorted values from both ends inward. When symmetry is found, the center and pair count are reported (e.g., `Symmetric about 500 (20 pairs)`); otherwise the line reads `None`. Requires at least 3 values. When `-T` is used, it is computed on the trimmed dataset and marked with `*`. |
+| **Symmetry**      | Reports whether the dataset is a mirror image of itself about a center value, checked by pairing the sorted values from both ends inward. When symmetry is found, the center and pair count are reported (e.g., `Symmetric about 500 (20 pairs)`); otherwise the line reads `None`. Requires at least 3 values. |
 | **Kurtosis**      | Excess kurtosis measuring the "tailedness" of the distribution. Values < -1 are platykurtic (flat, thin tails), between -1 and 1 are mesokurtic (normal-like), and > 1 are leptokurtic (peaked, heavy tails). |
 | **Outliers**      | Values that fall outside the range of `Q1 - k*IQR` and `Q3 + k*IQR`, where `k` defaults to 1.5 and can be adjusted with the `-k` flag.                                      |
-| **Z-Score Outliers** | Values whose Z-score (number of standard deviations from the mean) exceeds the threshold set with the `-z` flag. Only shown when `-z` is provided. Ideal for normally distributed data. |
+| **Z-Score Outliers** | Values whose Z-score (number of standard deviations from the mean) exceeds the threshold set with the `-z` flag. Only shown when `-z` is provided. Ideal for normally distributed data. Reads `N/A - standard deviation is zero` when every value is identical. |
 | **Mod Z-Outliers** | Values whose modified z-score (Iglewicz-Hoaglin: `0.6745 * (x - median) / MAD`) exceeds the same `-z` threshold. Robust against masking, where outliers inflate the mean and standard deviation enough to hide themselves from classic z-scores. Reads `N/A - MAD is zero` when more than half the values are identical. Only shown when `-z` is provided. |
 | **Histogram**     | A single-line Unicode histogram showing data distribution across bins. Each character represents a bin, with taller blocks indicating more values. Bin count is configurable with the `-b` flag (default 16). |
 | **Trendline**     | A single-line Unicode trendline showing the sequence pattern of values in their original input order. Data is divided into equal chunks, each averaged and mapped to a block character. Bin count is configurable with the `-b` flag (default 16). |
 | **Autocorrelation** | The lag-1 autocorrelation of the data in its original input order, measuring whether each value predicts the next. Values near 0 indicate no serial dependence; values near 1 or -1 indicate strong dependence. Cleared under `-T` because sorting destroys input order. |
 | **Input Order**   | Whether the data arrived `ascending`, `descending`, `constant`, or `unordered` (non-strict; ties allowed). When the input is sorted, a warning notes that the trendline and autocorrelation reflect the sort rather than any property of the data. Cleared under `-T`. |
-| **Trim Dataset** | When the `-T` flag is used, a `(trimmed dataset: ...)` header appears above the output showing the trim percentage and before/after counts. All statistics are computed on the reduced dataset. Tail-sensitive statistics (percentiles, MAD, skewness, kurtosis, outliers) are marked with `*`. The Trendline, Autocorrelation, and Input Order lines are suppressed. Mutually exclusive with `-t` and `-e`. |
+| **Trim Dataset** | When the `-T` flag is used, a `(trimmed dataset: ...)` header appears above the output showing the trim percentage and before/after counts. Every statistic is computed on the reduced dataset, Min and Max included. The Trendline, Autocorrelation, and Input Order lines are suppressed. Mutually exclusive with `-t` and `-e`. |
 | **Log Transform** | When the `-l` flag is used, a `(log-transformed, base e)` header appears above the output. All statistics are computed on `ln(x)` values. To convert back to original units, exponentiate (e.g., `e^mean`). Requires all input values to be positive. |
+| **Input Order warning** | When the input arrived already sorted, the Input Order line warns that the trendline and autocorrelation describe the sort rather than the data. The warning also names the EMA whenever `-e` is active, since the EMA of sorted data converges on the last value regardless of the data's actual behavior. |
 
 ## Testing and Correctness
 
-The program includes two layers of verification:
+The program has three independent verification layers, and all three run in CI on every push and pull request (`.github/workflows/build.yml`). A release is blocked unless they pass.
 
 ### Unit Tests (`stats_test.go`)
 
 Standard Go unit tests cover the core statistical functions:
 
 - `computeStats` - verifies all computed statistics against a 31-number dataset
-- `calculatePercentile` - tests percentile interpolation at various points (p0, p25, p50, p75, p100)
-- `calculateSkewness` - validates skewness calculations for symmetric and skewed distributions
+- `calculatePercentile` - tests percentile interpolation at various points (p0, p25, p50, p75, p100), plus custom percentiles requested via `-p`
+- `calculateSkewness` and `calculateKurtosis` - validate shape statistics for symmetric and skewed distributions, including the small-n and zero-variance guards
 - `detectSymmetry` - verifies mirror-symmetry detection across even and odd counts, duplicates, negative values, and float tolerance
-- `readNumbers` - verifies parsing, the skipped-line count, and that blank lines are not counted as skipped
+- `readNumbers` - verifies parsing, the skipped-line count, that blank lines are not counted as skipped, and that `NaN` and infinities are rejected rather than propagated into every downstream statistic
 - `calculateMAD` - validates the median absolute deviation against hand-computed cases, including a zero-MAD case
 - modified z-score outliers - constructs a masking case where classic z-scores miss two same-tail outliers that modified z-scores catch at the same threshold
 - `calculateGeometricMean` - checks a closed-form case, the ordering against the arithmetic mean, and suppression for non-positive data
 - `calculateAutocorrelation` - verifies lag-1 autocorrelation for ascending, alternating, and shuffled sequences, plus small-n and zero-variance guards
 - `detectMonotonicity` - covers ascending, descending, constant, unordered, and two-element inputs
-- CLI-level tests - confirm that `-T` suppresses the trendline, autocorrelation, and input-order lines, that `-l` suppresses the geometric mean, and that `-e` and `-T` are mutually exclusive
+- `formatFloat` - confirms that small magnitudes keep their significant digits and that scientific notation is never emitted
+- `generateHistogram` - confirms bins never outnumber observations and that an occupied bin never renders as the empty-bin glyph
+- modal bin - verifies the fallback appears only when no value repeats, and that its reported count matches the values actually inside the bin
+- 95% confidence interval - checks the interval is centered on the mean with a half-width of 1.96 standard errors, and is suppressed when the standard error is zero
+- CLI-level tests - confirm that `-T` suppresses the trendline, autocorrelation, and input-order lines, that `-l` suppresses the geometric mean, that `-t`/`-T` and `-e`/`-T` are mutually exclusive, that `-k` rejects non-positive multipliers, that options placed after the filename are rejected rather than silently ignored, and that `-j` emits parseable JSON matching the text output
+
+The CLI tests compile the package once into a temporary binary rather than shelling out to `go run stats.go`, so they keep working if the program is ever split across multiple files.
 
 Run the tests with:
 ```bash
 go test -v
 ```
 
-### Independent Verification (`verify_stats.sh`)
+### Independent Verification with bc (`verify_stats.sh`)
 
 A shell script independently calculates statistics using `bc` (arbitrary precision calculator) and compares the results against the program's output. This provides external validation that the Go implementation produces correct results.
 
+The script reads the program through its JSON output (`-j`) and parses it with `jq`, so it compares numbers against numbers instead of scraping padded text. Beyond the core statistics it verifies the 95% confidence interval, EMA, custom percentiles, IQR outlier counts at two `-k` values, the trimmed mean, the log transform, symmetry, skipped-line counting, input-order detection, degenerate zero-variance handling, small-magnitude formatting, and every mutually exclusive flag pair.
+
 The script was developed and tested on `MacOS Sequoia 15.7.3` using:
 - `bc` - arbitrary precision calculator for sum, mean, variance, standard deviation, and percentile calculations
+- `jq` - to read values out of the program's JSON output
 - `sort` - for ordering the dataset to verify percentile indices
 
 Run the verification with:
@@ -601,7 +693,20 @@ Run the verification with:
 ./verify_stats.sh
 ```
 
-The script exits with code `0` if all values match, or code `1` if any discrepancies are found.
+### Independent Verification with Python (`verify_stats.py`)
+
+A pure-Python reimplementation of every statistic, using only the standard library and no third-party numeric packages. It compares its own results field by field against the program's JSON output across eleven datasets: the 31-value fixture, the symmetric fixture, the masking fixture, sorted and reverse-sorted input, constant data, data with negative values, a single value, and runs with `-e`, `-t`, and a custom `-k`.
+
+Where `verify_stats.sh` trades breadth for bc's arbitrary precision on one dataset, this script trades precision for breadth. It reaches the parts that are impractical to express in bc: the histogram and trendline glyph strings across five bin counts, symmetry detection, the modal bin, monotonicity classification, every flag validation and rejection message, and a check that no numeric field is left non-finite after `NaN` and `Inf` lines are filtered out. It performs over 700 individual comparisons.
+
+Block-glyph strings are compared with a one-level tolerance. A chunk average can land exactly on a rounding boundary, where a one-ulp difference between Go's and Python's `log()` flips the chosen block; differences of two or more levels still fail.
+
+Run the verification with:
+```bash
+./verify_stats.py
+```
+
+Both scripts exit with code `0` if all values match, or code `1` if any discrepancies are found.
 
 ### Test Data Characteristics
 
@@ -614,7 +719,7 @@ A second fixture of 40 values exercises symmetry detection: 20 disjoint pairs, e
 
 A third fixture of 12 values (`masking_data.txt`) exercises masking in z-score outlier detection: a tight cluster around 11 with two adjacent outliers at 50 and 52. The outliers inflate the mean and standard deviation enough that neither reaches a classic z-score of 2.5, while both far exceed the modified z-score threshold built from the median and MAD. It exists to prove the two detection methods genuinely disagree on the same data.
 
-The tests focus on typical usage patterns and do not cover exotic edge cases, extreme values, or adversarial inputs. Users requiring high-assurance results for critical applications should perform additional validation appropriate to their use case.
+The tests focus on typical usage patterns and do not cover exotic edge cases, extreme values, or adversarial inputs. In particular, values near the limits of float64 (magnitudes around 1e300) can overflow the sum of squared deviations and produce an infinite variance, and are not guarded against. Users requiring high-assurance results for critical applications should perform additional validation appropriate to their use case.
 
 ## Acknowledgements
 

--- a/stats.go
+++ b/stats.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -20,7 +21,7 @@ const PgmUrl string = "https://github.com/jftuga/go-stats-calculator"
 const PgmDisclaimer string = "DISCLAIMER: This program is vibe-coded. Use at your own risk."
 const PgmSeeAlso string = "SEE ALSO: " + PgmUrl + "/tree/main?tab=readme-ov-file#testing-and-correctness"
 
-const PgmVersion string = "1.13.0"
+const PgmVersion string = "1.14.0"
 
 // madScale is the normal-consistency constant that makes the MAD directly
 // comparable to the standard deviation for normally distributed data.
@@ -30,52 +31,81 @@ const madScale = 1.4826
 // approximately the reciprocal of madScale.
 const modZScale = 0.6745
 
+// ci95Z is the standard normal critical value for a two-sided 95% interval.
+const ci95Z = 1.96
+
+// baseDecimals is the number of decimal places used for values of magnitude 1
+// or greater. Smaller magnitudes gain additional places so that they keep
+// roughly the same number of significant digits instead of rounding to zero.
+const baseDecimals = 4
+
 // Stats holds the computed statistical results.
 type Stats struct {
-	Count             int
-	SkippedLines      int // Input lines that failed to parse (blank lines excluded)
-	Distinct          int // Number of distinct values
-	Sum               float64
-	Mean              float64
-	StdErr            float64 // Standard error of the mean (StdDev / sqrt(n))
-	GeometricMean     float64 // Geometric mean; valid only when GeoMeanValid
-	GeoMeanValid      bool    // False when any value is non-positive or under log transform
-	Median            float64
-	Mode              []float64 // A dataset can have more than one mode
-	Min               float64
-	Max               float64
-	StdDev            float64 // Standard Deviation
-	Variance          float64 // Variance = StdDev^2
-	MAD               float64 // Median absolute deviation, scaled by madScale
-	Q1                float64 // 1st Quartile (25th percentile)
-	Q3                float64 // 3rd Quartile (75th percentile)
-	P95               float64 // 95th percentile
-	P99               float64 // 99th percentile
-	IQR               float64 // Interquartile Range (Q3 - Q1)
-	Outliers          []float64
-	ZScoreOutliers    []float64           // Outliers detected via Z-score method
-	ZScoreThreshold   float64             // Z-score threshold used (0 = disabled)
-	ModZOutliers      []float64           // Outliers detected via modified z-score (Iglewicz-Hoaglin)
-	Skewness          float64             // Formal skewness value
-	Kurtosis          float64             // Excess kurtosis
-	IsSymmetric       bool                // Dataset is a mirror image of itself about SymmetryCenter
-	SymmetryCenter    float64             // Center of reflection; valid only when IsSymmetric
-	SymmetryPairs     int                 // Number of mirrored pairs (excludes an odd-n center element)
-	CV                float64             // Coefficient of Variation as a percentage
-	HasNegativeData   bool                // Flag for negative value warning
-	CVValid           bool                // False when mean is near zero
-	CustomPercentiles map[float64]float64 // User-requested percentiles
-	Histogram         string              // Unicode histogram showing distribution
-	Trendline         string              // Unicode trendline showing sequence pattern
-	Autocorrelation   float64             // Lag-1 autocorrelation in input order; valid only when AutocorrValid
-	AutocorrValid     bool                // False when n < 3, zero variance, or dataset trimmed (-T)
-	InputOrder        string              // ascending, descending, constant, or unordered; empty when suppressed
-	TrimmedMean       float64
-	TrimmedMeanPct    float64 // 0 = disabled
-	TrimDatasetPct    float64 // 0 = disabled; trim dataset before all stats
-	TrimDatasetOrigN  int     // original count before dataset trimming
-	EMA               float64
-	EMASpan           int // 0 = disabled
+	Count             int                 `json:"count"`
+	SkippedLines      int                 `json:"skippedLines"` // Input lines that failed to parse (blank lines excluded)
+	Distinct          int                 `json:"distinct"`     // Number of distinct values
+	Sum               float64             `json:"sum"`
+	Mean              float64             `json:"mean"`
+	StdErr            float64             `json:"stdErr"`        // Standard error of the mean (StdDev / sqrt(n))
+	CI95Lower         float64             `json:"ci95Lower"`     // Lower bound of the 95% confidence interval for the mean
+	CI95Upper         float64             `json:"ci95Upper"`     // Upper bound of the 95% confidence interval for the mean
+	CIValid           bool                `json:"ciValid"`       // False when n < 2 or the standard error is zero
+	GeometricMean     float64             `json:"geometricMean"` // Geometric mean; valid only when GeoMeanValid
+	GeoMeanValid      bool                `json:"geoMeanValid"`  // False when any value is non-positive or under log transform
+	Median            float64             `json:"median"`
+	Mode              []float64           `json:"mode"`          // A dataset can have more than one mode
+	ModalBinLow       float64             `json:"modalBinLow"`   // Lower edge of the densest histogram bin; valid only when ModalBinValid
+	ModalBinHigh      float64             `json:"modalBinHigh"`  // Upper edge of the densest histogram bin
+	ModalBinCount     int                 `json:"modalBinCount"` // Number of values in the densest bin
+	ModalBinValid     bool                `json:"modalBinValid"` // True only when no value repeats and the data has spread
+	Min               float64             `json:"min"`
+	Max               float64             `json:"max"`
+	StdDev            float64             `json:"stdDev"`   // Standard Deviation
+	Variance          float64             `json:"variance"` // Variance = StdDev^2
+	MAD               float64             `json:"mad"`      // Median absolute deviation, scaled by madScale
+	Q1                float64             `json:"q1"`       // 1st Quartile (25th percentile)
+	Q3                float64             `json:"q3"`       // 3rd Quartile (75th percentile)
+	P95               float64             `json:"p95"`      // 95th percentile
+	P99               float64             `json:"p99"`      // 99th percentile
+	IQR               float64             `json:"iqr"`      // Interquartile Range (Q3 - Q1)
+	IQRMultiplier     float64             `json:"iqrMultiplier"`
+	Outliers          []float64           `json:"outliers"`
+	ZScoreOutliers    []float64           `json:"zScoreOutliers"`  // Outliers detected via Z-score method; null when not computed
+	ZScoreThreshold   float64             `json:"zScoreThreshold"` // Z-score threshold used (0 = disabled)
+	ZScoreValid       bool                `json:"zScoreValid"`     // False when -z is given but the standard deviation is zero
+	ModZOutliers      []float64           `json:"modZOutliers"`    // Outliers via modified z-score (Iglewicz-Hoaglin); null when not computed
+	ModZValid         bool                `json:"modZValid"`       // False when -z is given but the MAD is zero
+	Skewness          float64             `json:"skewness"`        // Formal skewness value
+	Kurtosis          float64             `json:"kurtosis"`        // Excess kurtosis
+	IsSymmetric       bool                `json:"isSymmetric"`     // Dataset is a mirror image of itself about SymmetryCenter
+	SymmetryCenter    float64             `json:"symmetryCenter"`  // Center of reflection; valid only when IsSymmetric
+	SymmetryPairs     int                 `json:"symmetryPairs"`   // Number of mirrored pairs (excludes an odd-n center element)
+	CV                float64             `json:"cv"`              // Coefficient of Variation as a percentage
+	HasNegativeData   bool                `json:"hasNegativeData"` // Flag for negative value warning
+	CVValid           bool                `json:"cvValid"`         // False when mean is near zero
+	CustomPercentiles map[float64]float64 `json:"-"`               // User-requested percentiles; see statsOutput
+	Histogram         string              `json:"histogram"`       // Unicode histogram showing distribution
+	Trendline         string              `json:"trendline"`       // Unicode trendline showing sequence pattern
+	Autocorrelation   float64             `json:"autocorrelation"` // Lag-1 autocorrelation in input order; valid only when AutocorrValid
+	AutocorrValid     bool                `json:"autocorrValid"`   // False when n < 3, zero variance, or dataset trimmed (-T)
+	InputOrder        string              `json:"inputOrder"`      // ascending, descending, constant, or unordered; empty when suppressed
+	TrimmedMean       float64             `json:"trimmedMean"`
+	TrimmedMeanPct    float64             `json:"trimmedMeanPct"`   // 0 = disabled
+	TrimDatasetPct    float64             `json:"trimDatasetPct"`   // 0 = disabled; trim dataset before all stats
+	TrimDatasetOrigN  int                 `json:"trimDatasetOrigN"` // original count before dataset trimming
+	EMA               float64             `json:"ema"`
+	EMASpan           int                 `json:"emaSpan"` // 0 = disabled
+}
+
+// statsOutput is the JSON view of a Stats value. It embeds Stats so every field
+// is emitted without duplication, and adds the run metadata plus the string-keyed
+// percentile map that encoding/json requires.
+type statsOutput struct {
+	*Stats
+	Version           string             `json:"version"`
+	LogTransformed    bool               `json:"logTransformed"`
+	DuplicatePct      float64            `json:"duplicatePct"`
+	CustomPercentiles map[string]float64 `json:"customPercentiles,omitempty"`
 }
 
 func main() {
@@ -94,10 +124,22 @@ func main() {
 	trimPct := flag.Float64("t", 0, "trimmed mean percentage to remove from each tail (0-50)")
 	trimDatasetPct := flag.Float64("T", 0, "trim dataset: remove percentage from each tail before computing all statistics (0-50)")
 	emaSpan := flag.Int("e", 0, "EMA span (number of periods) for exponential moving average (>= 2)")
+	jsonOutput := flag.Bool("j", false, "emit results as JSON instead of formatted text")
 	flag.Parse()
+
+	// Handled before validation so the version is always reachable.
+	if *version {
+		fmt.Printf("%s version %s\n%s\n\n%s\n%s\n", PgmName, PgmVersion, PgmUrl, PgmDisclaimer, PgmSeeAlso)
+		os.Exit(0)
+	}
 
 	if *numBins < 5 || *numBins > 50 {
 		fmt.Fprintf(os.Stderr, "Error: number of bins must be between 5 and 50, got %d\n", *numBins)
+		os.Exit(1)
+	}
+
+	if *iqrMultiplier <= 0 {
+		fmt.Fprintf(os.Stderr, "Error: IQR multiplier must be greater than 0, got %v\n", *iqrMultiplier)
 		os.Exit(1)
 	}
 
@@ -131,11 +173,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *version {
-		fmt.Printf("%s version %s\n%s\n\n%s\n%s\n", PgmName, PgmVersion, PgmUrl, PgmDisclaimer, PgmSeeAlso)
-		os.Exit(0)
-	}
 	args := flag.Args()
+	// Go's flag package stops parsing at the first non-flag argument, so anything
+	// after the filename would otherwise be accepted and silently ignored.
+	if len(args) > 1 {
+		fmt.Fprintf(os.Stderr, "Error: expected at most one input file, got %d arguments: %s\n", len(args), strings.Join(args, " "))
+		fmt.Fprintf(os.Stderr, "Note: options must appear before the filename, e.g. %s -z 2.0 data.txt\n", PgmName)
+		os.Exit(1)
+	}
+
 	// Determine whether stdin is a terminal
 	inputIsTerminal := term.IsTerminal(int(os.Stdin.Fd()))
 
@@ -225,7 +271,15 @@ func main() {
 		stats.GeoMeanValid = false
 	}
 
-	labelWidth := 18 // len("Quartile 1 (p25):")
+	if *jsonOutput {
+		if err := printJSON(stats, *logTransform); err != nil {
+			fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	labelWidth := 18 // one more than len("Quartile 1 (p25):")
 	for _, p := range customPercentiles {
 		label := fmt.Sprintf("Percentile (p%s):", formatFloat(p))
 		if len(label) > labelWidth {
@@ -254,9 +308,6 @@ func main() {
 			labelWidth = len(label)
 		}
 	}
-	if *trimDatasetPct > 0 {
-		labelWidth++ // account for * suffix on labels
-	}
 	labelWidth++ // ensure padding via fmt.Sprintf, not the label+space fallback in padLabel
 	if *logTransform {
 		fmt.Println("(log-transformed, base e)")
@@ -269,9 +320,43 @@ func main() {
 	printStats(stats, labelWidth)
 }
 
+// printJSON writes the statistics to stdout as an indented JSON object.
+// Outlier lists follow a two-state convention: an empty array means the detector
+// ran and found nothing, while null means it never ran.
+func printJSON(s *Stats, logTransformed bool) error {
+	if s.Outliers == nil {
+		s.Outliers = []float64{}
+	}
+	if s.ZScoreValid && s.ZScoreOutliers == nil {
+		s.ZScoreOutliers = []float64{}
+	}
+	if s.ModZValid && s.ModZOutliers == nil {
+		s.ModZOutliers = []float64{}
+	}
+
+	out := statsOutput{
+		Stats:          s,
+		Version:        PgmVersion,
+		LogTransformed: logTransformed,
+		DuplicatePct:   float64(s.Count-s.Distinct) / float64(s.Count) * 100,
+	}
+	if len(s.CustomPercentiles) > 0 {
+		out.CustomPercentiles = make(map[string]float64, len(s.CustomPercentiles))
+		for k, v := range s.CustomPercentiles {
+			out.CustomPercentiles[formatFloat(k)] = v
+		}
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(out)
+}
+
 // readNumbers reads floating-point numbers (one per line) from an io.Reader.
 // It also returns the count of invalid lines that were skipped; blank lines
-// are skipped silently and do not count toward that total.
+// are skipped silently and do not count toward that total. NaN and infinities
+// parse successfully but are rejected, because a single one propagates through
+// every downstream statistic.
 func readNumbers(reader io.Reader) ([]float64, int, error) {
 	var numbers []float64
 	skipped := 0
@@ -285,7 +370,7 @@ func readNumbers(reader io.Reader) ([]float64, int, error) {
 		}
 
 		num, err := strconv.ParseFloat(line, 64)
-		if err != nil {
+		if err != nil || math.IsNaN(num) || math.IsInf(num, 0) {
 			// Log invalid lines but continue processing
 			fmt.Fprintf(
 				os.Stderr,
@@ -327,9 +412,10 @@ func computeStats(data []float64, customPercentiles []float64, iqrMultiplier flo
 
 	// --- Basic Stats ---
 	stats := &Stats{
-		Count: count,
-		Min:   sortedData[0],
-		Max:   sortedData[count-1],
+		Count:         count,
+		Min:           sortedData[0],
+		Max:           sortedData[count-1],
+		IQRMultiplier: iqrMultiplier,
 	}
 
 	// --- Mean ---
@@ -369,6 +455,13 @@ func computeStats(data []float64, customPercentiles []float64, iqrMultiplier flo
 
 	// --- Standard Error of the Mean ---
 	stats.StdErr = stats.StdDev / math.Sqrt(float64(count))
+
+	// --- 95% Confidence Interval for the Mean (normal approximation) ---
+	if count > 1 && stats.StdErr > 0 {
+		stats.CI95Lower = stats.Mean - ci95Z*stats.StdErr
+		stats.CI95Upper = stats.Mean + ci95Z*stats.StdErr
+		stats.CIValid = true
+	}
 
 	// --- Geometric Mean ---
 	if sortedData[0] > 0 {
@@ -420,6 +513,15 @@ func computeStats(data []float64, customPercentiles []float64, iqrMultiplier flo
 	// If the max frequency is 1, it means no number repeated, so there is no mode.
 	if maxFreq <= 1 {
 		stats.Mode = []float64{} // Return an empty slice
+		// Exact repeats are vanishingly rare in continuous measurements, so fall
+		// back to the densest histogram bin, which is what "most common" means there.
+		low, high, binCount, ok := findModalBin(sortedData, numBins)
+		if ok {
+			stats.ModalBinLow = low
+			stats.ModalBinHigh = high
+			stats.ModalBinCount = binCount
+			stats.ModalBinValid = true
+		}
 	} else {
 		stats.Mode = modes
 		sort.Float64s(stats.Mode) // For consistent output
@@ -436,28 +538,35 @@ func computeStats(data []float64, customPercentiles []float64, iqrMultiplier flo
 	}
 	sort.Float64s(stats.Outliers) // For consistent output
 
-	// --- Z-Score Outliers ---
-	if zScoreThreshold > 0 && stats.StdDev > 0 {
+	// --- Z-Score and Modified Z-Score Outliers ---
+	// The threshold is recorded whenever it was requested, so a degenerate
+	// dataset reports "N/A" rather than silently dropping the whole section.
+	if zScoreThreshold > 0 {
 		stats.ZScoreThreshold = zScoreThreshold
-		for _, v := range data {
-			z := math.Abs((v - stats.Mean) / stats.StdDev)
-			if z > zScoreThreshold {
-				stats.ZScoreOutliers = append(stats.ZScoreOutliers, v)
-			}
-		}
-		sort.Float64s(stats.ZScoreOutliers)
-	}
+		stats.ZScoreValid = stats.StdDev > 0
+		stats.ModZValid = stats.MAD > 0
 
-	// --- Modified Z-Score Outliers (Iglewicz-Hoaglin) ---
-	if stats.ZScoreThreshold > 0 && stats.MAD > 0 {
-		rawMAD := stats.MAD / madScale // unscaled median absolute deviation
-		for _, v := range data {
-			m := math.Abs(modZScale * (v - stats.Median) / rawMAD)
-			if m > zScoreThreshold {
-				stats.ModZOutliers = append(stats.ModZOutliers, v)
+		if stats.ZScoreValid {
+			for _, v := range data {
+				z := math.Abs((v - stats.Mean) / stats.StdDev)
+				if z > zScoreThreshold {
+					stats.ZScoreOutliers = append(stats.ZScoreOutliers, v)
+				}
 			}
+			sort.Float64s(stats.ZScoreOutliers)
 		}
-		sort.Float64s(stats.ModZOutliers)
+
+		// --- Modified Z-Score Outliers (Iglewicz-Hoaglin) ---
+		if stats.ModZValid {
+			rawMAD := stats.MAD / madScale // unscaled median absolute deviation
+			for _, v := range data {
+				m := math.Abs(modZScale * (v - stats.Median) / rawMAD)
+				if m > zScoreThreshold {
+					stats.ModZOutliers = append(stats.ModZOutliers, v)
+				}
+			}
+			sort.Float64s(stats.ModZOutliers)
+		}
 	}
 
 	// --- Skewness (formal calculation) ---
@@ -511,27 +620,42 @@ func computeStats(data []float64, customPercentiles []float64, iqrMultiplier flo
 	return stats, nil
 }
 
-// generateHistogram creates a Unicode histogram from sorted data.
-func generateHistogram(sortedData []float64, numBins int) string {
+// binData buckets sortedData into equal-width bins spanning [min, max] and returns
+// the bin counts, the minimum value, and the bin width. numBins is capped at the
+// number of values so bins can never outnumber observations. It returns a nil slice
+// when the data has fewer than two values or no spread, in which case binning is
+// meaningless.
+func binData(sortedData []float64, numBins int) ([]int, float64, float64) {
 	n := len(sortedData)
 	if n < 2 {
-		return ""
+		return nil, 0, 0
 	}
 	minVal := sortedData[0]
 	maxVal := sortedData[n-1]
 	if minVal == maxVal {
-		return ""
+		return nil, 0, 0
+	}
+	if numBins > n {
+		numBins = n
 	}
 
 	binWidth := (maxVal - minVal) / float64(numBins)
 	bins := make([]int, numBins)
-
 	for _, v := range sortedData {
 		idx := int((v - minVal) / binWidth)
 		if idx >= numBins {
 			idx = numBins - 1
 		}
 		bins[idx]++
+	}
+	return bins, minVal, binWidth
+}
+
+// generateHistogram creates a Unicode histogram from sorted data.
+func generateHistogram(sortedData []float64, numBins int) string {
+	bins, _, _ := binData(sortedData, numBins)
+	if bins == nil {
+		return ""
 	}
 
 	maxCount := 0
@@ -542,16 +666,40 @@ func generateHistogram(sortedData []float64, numBins int) string {
 	}
 
 	blocks := []rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
-	runes := make([]rune, numBins)
+	runes := make([]rune, len(bins))
 	for i, c := range bins {
 		if c == 0 {
 			runes[i] = blocks[0]
-		} else {
-			level := (c * 7) / maxCount
-			runes[i] = blocks[level]
+			continue
 		}
+		// Floor occupied bins one level above empty so a sparse bin is visually
+		// distinct from a bin holding nothing at all.
+		level := (c * 7) / maxCount
+		if level == 0 {
+			level = 1
+		}
+		runes[i] = blocks[level]
 	}
 	return string(runes)
+}
+
+// findModalBin returns the edges and count of the densest histogram bin. It is used
+// in place of the mode for continuous data, where exact repeats almost never occur.
+// The ok result is false when the data cannot be binned.
+func findModalBin(sortedData []float64, numBins int) (low float64, high float64, count int, ok bool) {
+	bins, minVal, binWidth := binData(sortedData, numBins)
+	if bins == nil {
+		return 0, 0, 0, false
+	}
+	best := 0
+	for i, c := range bins {
+		if c > bins[best] {
+			best = i
+		}
+	}
+	low = minVal + float64(best)*binWidth
+	high = low + binWidth
+	return low, high, bins[best], true
 }
 
 // generateTrendline creates a Unicode trendline from data in its original input order.
@@ -809,12 +957,26 @@ func interpretCV(cv float64) string {
 	return "High Variability"
 }
 
-// formatFloat formats a float64 without scientific notation, trimming unnecessary trailing zeros.
+// decimalsFor reports how many decimal places formatFloat should use for a value.
+// Magnitudes of 1 or greater use baseDecimals; smaller magnitudes gain one place per
+// leading zero so that a value like 0.00004 keeps its significant digits instead of
+// rounding away to 0.
+func decimalsFor(v float64) int {
+	abs := math.Abs(v)
+	if abs == 0 || abs >= 1 || math.IsNaN(abs) || math.IsInf(abs, 0) {
+		return baseDecimals
+	}
+	return baseDecimals - int(math.Floor(math.Log10(abs))) - 1
+}
+
+// formatFloat formats a float64 without scientific notation, trimming unnecessary
+// trailing zeros. The decimal width adapts to the magnitude of the value, so small
+// numbers survive formatting rather than collapsing to 0.
 func formatFloat(v float64) string {
 	if v == math.Trunc(v) {
 		return strconv.FormatFloat(v, 'f', 0, 64)
 	}
-	s := strconv.FormatFloat(v, 'f', 4, 64)
+	s := strconv.FormatFloat(v, 'f', decimalsFor(v), 64)
 	s = strings.TrimRight(s, "0")
 	s = strings.TrimSuffix(s, ".")
 	return s
@@ -859,12 +1021,28 @@ func padLabel(label string, labelWidth int) string {
 	return padded
 }
 
+// formatMode renders the mode line value, falling back to the densest histogram bin
+// when no value repeats.
+func formatMode(s *Stats) string {
+	switch {
+	case len(s.Mode) == 1:
+		return formatFloat(s.Mode[0])
+	case len(s.Mode) > 1:
+		return formatFloatSlice(s.Mode)
+	case s.ModalBinValid:
+		valueWord := "values"
+		if s.ModalBinCount == 1 {
+			valueWord = "value"
+		}
+		return fmt.Sprintf("None (modal bin: %s-%s, %d %s)",
+			formatFloat(s.ModalBinLow), formatFloat(s.ModalBinHigh), s.ModalBinCount, valueWord)
+	default:
+		return "None"
+	}
+}
+
 // printStats displays the results in a readable format.
 func printStats(s *Stats, labelWidth int) {
-	star := ""
-	if s.TrimDatasetPct > 0 {
-		star = "*"
-	}
 	fmt.Println("--- Descriptive Statistics ---")
 	fmt.Printf("%s%d\n", padLabel("Count:", labelWidth), s.Count)
 	if s.SkippedLines > 0 {
@@ -882,6 +1060,10 @@ func printStats(s *Stats, labelWidth int) {
 	fmt.Println("\n--- Measures of Central Tendency ---")
 	fmt.Printf("%s%s\n", padLabel("Mean:", labelWidth), formatFloat(s.Mean))
 	fmt.Printf("%s%s\n", padLabel("Std Error:", labelWidth), formatFloat(s.StdErr))
+	if s.CIValid {
+		ci := fmt.Sprintf("[%s, %s]", formatFloat(s.CI95Lower), formatFloat(s.CI95Upper))
+		fmt.Printf("%s%s\n", padLabel("95% CI (mean):", labelWidth), ci)
+	}
 	if s.GeoMeanValid {
 		fmt.Printf("%s%s\n", padLabel("Geometric Mean:", labelWidth), formatFloat(s.GeometricMean))
 	}
@@ -895,21 +1077,16 @@ func printStats(s *Stats, labelWidth int) {
 	}
 	fmt.Printf("%s%s\n", padLabel("Median (p50):", labelWidth), formatFloat(s.Median))
 
-	switch len(s.Mode) {
-	case 0:
-		fmt.Printf("%s%s\n", padLabel("Mode:", labelWidth), "None")
-	case 1:
-		// If there's only one mode, print it as a clean number.
-		fmt.Printf("%s%s\n", padLabel("Mode:", labelWidth), formatFloat(s.Mode[0]))
-	default:
-		// If there are multiple modes, label it and print the slice.
-		fmt.Printf("%s%s\n", padLabel("Mode (multi):", labelWidth), formatFloatSlice(s.Mode))
+	modeLabel := "Mode:"
+	if len(s.Mode) > 1 {
+		modeLabel = "Mode (multi):"
 	}
+	fmt.Printf("%s%s\n", padLabel(modeLabel, labelWidth), formatMode(s))
 
 	fmt.Println("\n--- Measures of Spread & Distribution ---")
 	fmt.Printf("%s%s\n", padLabel("Std Deviation:", labelWidth), formatFloat(s.StdDev))
 	fmt.Printf("%s%s\n", padLabel("Variance:", labelWidth), formatFloat(s.Variance))
-	fmt.Printf("%s%s\n", padLabel("MAD"+star+":", labelWidth), formatFloat(s.MAD))
+	fmt.Printf("%s%s\n", padLabel("MAD:", labelWidth), formatFloat(s.MAD))
 	if !s.CVValid {
 		fmt.Printf("%s%s\n", padLabel("CV:", labelWidth), "N/A - mean near zero")
 	} else {
@@ -931,12 +1108,12 @@ func printStats(s *Stats, labelWidth int) {
 	}
 	sort.Float64s(pctKeys)
 	for _, k := range pctKeys {
-		label := fmt.Sprintf("Percentile (p%s)%s:", formatFloat(k), star)
+		label := fmt.Sprintf("Percentile (p%s):", formatFloat(k))
 		fmt.Printf("%s%s\n", padLabel(label, labelWidth), formatFloat(allPercentiles[k]))
 	}
 	fmt.Printf("%s%s\n", padLabel("IQR:", labelWidth), formatFloat(s.IQR))
-	fmt.Printf("%s%s (%s)\n", padLabel("Skewness"+star+":", labelWidth), formatFloat(s.Skewness), interpretSkewness(s.Skewness))
-	fmt.Printf("%s%s (%s)\n", padLabel("Kurtosis"+star+":", labelWidth), formatFloat(s.Kurtosis), interpretKurtosis(s.Kurtosis))
+	fmt.Printf("%s%s (%s)\n", padLabel("Skewness:", labelWidth), formatFloat(s.Skewness), interpretSkewness(s.Skewness))
+	fmt.Printf("%s%s (%s)\n", padLabel("Kurtosis:", labelWidth), formatFloat(s.Kurtosis), interpretKurtosis(s.Kurtosis))
 	symmetryStr := "N/A - requires at least 3 values"
 	if s.Count >= 3 {
 		if s.IsSymmetric {
@@ -953,25 +1130,29 @@ func printStats(s *Stats, labelWidth int) {
 			symmetryStr = "None"
 		}
 	}
-	fmt.Printf("%s%s\n", padLabel("Symmetry"+star+":", labelWidth), symmetryStr)
+	fmt.Printf("%s%s\n", padLabel("Symmetry:", labelWidth), symmetryStr)
 	if len(s.Outliers) > 0 {
-		fmt.Printf("%s%s\n", padLabel("Outliers"+star+":", labelWidth), formatFloatSlice(s.Outliers))
+		fmt.Printf("%s%s\n", padLabel("Outliers:", labelWidth), formatFloatSlice(s.Outliers))
 	} else {
-		fmt.Printf("%s%s\n", padLabel("Outliers"+star+":", labelWidth), "None")
+		fmt.Printf("%s%s\n", padLabel("Outliers:", labelWidth), "None")
 	}
 	if s.ZScoreThreshold > 0 {
-		label := fmt.Sprintf("Z-Outliers (Z>%s)%s:", formatFloat(s.ZScoreThreshold), star)
-		if len(s.ZScoreOutliers) > 0 {
+		label := fmt.Sprintf("Z-Outliers (Z>%s):", formatFloat(s.ZScoreThreshold))
+		switch {
+		case !s.ZScoreValid:
+			fmt.Printf("%s%s\n", padLabel(label, labelWidth), "N/A - standard deviation is zero")
+		case len(s.ZScoreOutliers) > 0:
 			fmt.Printf("%s%s\n", padLabel(label, labelWidth), formatFloatSlice(s.ZScoreOutliers))
-		} else {
+		default:
 			fmt.Printf("%s%s\n", padLabel(label, labelWidth), "None")
 		}
-		label = fmt.Sprintf("Mod Z-Outliers (Z>%s)%s:", formatFloat(s.ZScoreThreshold), star)
-		if s.MAD == 0 {
+		label = fmt.Sprintf("Mod Z-Outliers (Z>%s):", formatFloat(s.ZScoreThreshold))
+		switch {
+		case !s.ModZValid:
 			fmt.Printf("%s%s\n", padLabel(label, labelWidth), "N/A - MAD is zero")
-		} else if len(s.ModZOutliers) > 0 {
+		case len(s.ModZOutliers) > 0:
 			fmt.Printf("%s%s\n", padLabel(label, labelWidth), formatFloatSlice(s.ModZOutliers))
-		} else {
+		default:
 			fmt.Printf("%s%s\n", padLabel(label, labelWidth), "None")
 		}
 	}
@@ -989,12 +1170,17 @@ func printStats(s *Stats, labelWidth int) {
 		if s.InputOrder != "" {
 			orderStr := s.InputOrder
 			if s.InputOrder == "ascending" || s.InputOrder == "descending" {
-				orderStr += " WARNING: trendline and autocorrelation reflect this sort order, not a property of the data"
+				// EMA is order-dependent too, so name it whenever it is on display.
+				affected := "trendline and autocorrelation"
+				if s.EMASpan > 0 {
+					affected = "trendline, autocorrelation, and EMA"
+				}
+				orderStr += " WARNING: " + affected + " reflect this sort order, not a property of the data"
 			}
 			fmt.Printf("%s%s\n", padLabel("Input Order:", labelWidth), orderStr)
 		}
 	}
 	if s.TrimDatasetPct > 0 {
-		fmt.Println("\n* computed on trimmed dataset; tail-sensitive statistics may differ from full data")
+		fmt.Println("\n* all statistics above are computed on the trimmed dataset; compare against the full-data output")
 	}
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"math"
 	"os"
 	"os/exec"
@@ -12,6 +14,34 @@ import (
 )
 
 const epsilon = 1e-4
+
+// statsBin is the path to the binary compiled once for the CLI-level tests. Building
+// the whole package (rather than "go run stats.go") keeps these tests working if the
+// program is ever split across multiple files.
+var statsBin string
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "stats-cli")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	statsBin = filepath.Join(dir, "stats")
+	if out, err := exec.Command("go", "build", "-o", statsBin, ".").CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build test binary: %v\n%s", err, out)
+		os.RemoveAll(dir)
+		os.Exit(1)
+	}
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// runStats executes the compiled binary and returns its combined output.
+func runStats(args ...string) (string, error) {
+	out, err := exec.Command(statsBin, args...).CombinedOutput()
+	return string(out), err
+}
 
 func floatEquals(a, b float64) bool {
 	return math.Abs(a-b) < epsilon
@@ -134,6 +164,13 @@ func TestComputeStatsSingleValue(t *testing.T) {
 	// StdDev and Variance should be 0 for single value
 	if !floatEquals(stats.StdDev, 0) {
 		t.Errorf("StdDev: got %v, expected 0", stats.StdDev)
+	}
+	if !floatEquals(stats.Variance, 0) {
+		t.Errorf("Variance: got %v, expected 0", stats.Variance)
+	}
+	// A confidence interval needs at least two observations
+	if stats.CIValid {
+		t.Error("CIValid: got true, expected false for a single value")
 	}
 }
 
@@ -736,26 +773,50 @@ func TestTrimDataset(t *testing.T) {
 }
 
 func TestTrimDatasetTooSmall(t *testing.T) {
-	// 3 values with trim=50%: trimCount = floor(3*50/100) = 1, remaining = 1 → should work
 	// 2 values with trim=50%: trimCount = floor(2*50/100) = 1, remaining = 0 → error
-	sorted := []float64{1, 2}
-	sort.Float64s(sorted)
-	trimCount := int(math.Floor(float64(len(sorted)) * 50 / 100.0))
-	remaining := len(sorted) - 2*trimCount
-	if remaining >= 1 {
-		t.Errorf("Expected remaining < 1 for 2 values at 50%% trim, got %d", remaining)
+	tooSmall := writeTempData(t, []float64{1, 2})
+	output, err := runStats("-T", "50", tooSmall)
+	if err == nil {
+		t.Fatalf("expected error trimming 50%% from 2 values, got none:\n%s", output)
+	}
+	if !strings.Contains(output, "dataset too small") {
+		t.Errorf("expected 'dataset too small' error, got: %s", output)
+	}
+
+	// 3 values with trim=50%: trimCount = floor(3*50/100) = 1, remaining = 1 → succeeds
+	justEnough := writeTempData(t, []float64{1, 2, 3})
+	output, err = runStats("-T", "50", justEnough)
+	if err != nil {
+		t.Fatalf("expected success trimming 50%% from 3 values: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "3 → 1 values") {
+		t.Errorf("expected header showing 3 → 1 values, got:\n%s", output)
 	}
 }
 
 func TestTrimDatasetMutualExclusion(t *testing.T) {
-	cmd := exec.Command("go", "run", "stats.go", "-t", "10", "-T", "10", "test_data.txt")
-	output, err := cmd.CombinedOutput()
+	output, err := runStats("-t", "10", "-T", "10", "test_data.txt")
 	if err == nil {
 		t.Fatal("Expected error when using both -t and -T, but got none")
 	}
-	if !strings.Contains(string(output), "mutually exclusive") {
-		t.Errorf("Expected mutual exclusion error message, got: %s", string(output))
+	if !strings.Contains(output, "mutually exclusive") {
+		t.Errorf("Expected mutual exclusion error message, got: %s", output)
 	}
+}
+
+// writeTempData writes values one per line to a temp file and returns its path.
+func writeTempData(t *testing.T, values []float64) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "data.txt")
+	var sb strings.Builder
+	for _, v := range values {
+		sb.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+		sb.WriteString("\n")
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	return path
 }
 
 func TestCalculateEMA(t *testing.T) {
@@ -1011,22 +1072,20 @@ func TestSymmetryOutputLine(t *testing.T) {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
 
-	cmd := exec.Command("go", "run", "stats.go", path)
-	output, err := cmd.CombinedOutput()
+	output, err := runStats(path)
 	if err != nil {
-		t.Fatalf("go run failed: %v\n%s", err, string(output))
+		t.Fatalf("stats failed: %v\n%s", err, output)
 	}
-	if !strings.Contains(string(output), "Symmetric about 500 (20 pairs)") {
-		t.Errorf("expected symmetric output line, got:\n%s", string(output))
+	if !strings.Contains(output, "Symmetric about 500 (20 pairs)") {
+		t.Errorf("expected symmetric output line, got:\n%s", output)
 	}
 
-	cmd = exec.Command("go", "run", "stats.go", "test_data.txt")
-	output, err = cmd.CombinedOutput()
+	output, err = runStats("test_data.txt")
 	if err != nil {
-		t.Fatalf("go run failed: %v\n%s", err, string(output))
+		t.Fatalf("stats failed: %v\n%s", err, output)
 	}
 	found := false
-	for _, line := range strings.Split(string(output), "\n") {
+	for _, line := range strings.Split(output, "\n") {
 		if strings.HasPrefix(line, "Symmetry:") {
 			found = true
 			if !strings.Contains(line, "None") {
@@ -1035,7 +1094,7 @@ func TestSymmetryOutputLine(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("Symmetry line not found in output:\n%s", string(output))
+		t.Errorf("Symmetry line not found in output:\n%s", output)
 	}
 }
 
@@ -1304,39 +1363,623 @@ func TestDetectMonotonicity(t *testing.T) {
 }
 
 func TestOrderStatisticsSuppressedUnderTrim(t *testing.T) {
-	cmd := exec.Command("go", "run", "stats.go", "-T", "10", "test_data.txt")
-	output, err := cmd.CombinedOutput()
+	output, err := runStats("-T", "10", "test_data.txt")
 	if err != nil {
-		t.Fatalf("go run failed: %v\n%s", err, string(output))
+		t.Fatalf("stats failed: %v\n%s", err, output)
 	}
 	for _, label := range []string{"Trendline:", "Autocorrelation:", "Input Order:"} {
-		if strings.Contains(string(output), label) {
-			t.Errorf("expected no %q line under -T, got:\n%s", label, string(output))
+		if strings.Contains(output, label) {
+			t.Errorf("expected no %q line under -T, got:\n%s", label, output)
 		}
 	}
-	if !strings.Contains(string(output), "MAD*:") {
-		t.Errorf("expected starred MAD line under -T, got:\n%s", string(output))
+	if !strings.Contains(output, "(trimmed dataset: 10% from each tail, 31 → 25 values)") {
+		t.Errorf("expected trimmed-dataset header under -T, got:\n%s", output)
+	}
+	if !strings.Contains(output, "all statistics above are computed on the trimmed dataset") {
+		t.Errorf("expected trimmed-dataset footnote under -T, got:\n%s", output)
+	}
+}
+
+// The star convention was dropped: under -T every statistic is computed on the
+// trimmed dataset, so marking a subset implied the rest were unaffected.
+func TestNoStarMarkersUnderTrim(t *testing.T) {
+	output, err := runStats("-T", "10", "test_data.txt")
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		label, _, found := strings.Cut(line, ":")
+		if found && strings.HasSuffix(label, "*") {
+			t.Errorf("unexpected star marker on label %q", label)
+		}
 	}
 }
 
 func TestGeometricSuppressedUnderLogTransform(t *testing.T) {
-	cmd := exec.Command("go", "run", "stats.go", "-l", "test_data.txt")
-	output, err := cmd.CombinedOutput()
+	output, err := runStats("-l", "test_data.txt")
 	if err != nil {
-		t.Fatalf("go run failed: %v\n%s", err, string(output))
+		t.Fatalf("stats failed: %v\n%s", err, output)
 	}
-	if strings.Contains(string(output), "Geometric Mean") {
-		t.Errorf("expected no Geometric Mean line under -l, got:\n%s", string(output))
+	if strings.Contains(output, "Geometric Mean") {
+		t.Errorf("expected no Geometric Mean line under -l, got:\n%s", output)
 	}
 }
 
 func TestEMATrimDatasetMutualExclusion(t *testing.T) {
-	cmd := exec.Command("go", "run", "stats.go", "-e", "5", "-T", "10", "test_data.txt")
-	output, err := cmd.CombinedOutput()
+	output, err := runStats("-e", "5", "-T", "10", "test_data.txt")
 	if err == nil {
 		t.Fatal("Expected error when using both -e and -T, but got none")
 	}
-	if !strings.Contains(string(output), "mutually exclusive") {
-		t.Errorf("Expected mutual exclusion error message, got: %s", string(output))
+	if !strings.Contains(output, "mutually exclusive") {
+		t.Errorf("Expected mutual exclusion error message, got: %s", output)
+	}
+}
+
+// --- Input validation: NaN and infinities parse but must be rejected ---
+
+func TestReadNumbersRejectsNonFinite(t *testing.T) {
+	input := "1\nNaN\n2\nInf\n3\n+Inf\n-Inf\n4\n"
+	numbers, skipped, err := readNumbers(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("readNumbers returned error: %v", err)
+	}
+	expected := []float64{1, 2, 3, 4}
+	if !floatSliceEquals(numbers, expected) {
+		t.Errorf("readNumbers: got %v, expected %v", numbers, expected)
+	}
+	// NaN, Inf, +Inf, -Inf all count as invalid lines
+	if skipped != 4 {
+		t.Errorf("skipped: got %d, expected 4", skipped)
+	}
+}
+
+func TestNonFiniteInputDoesNotPoisonOutput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nan.txt")
+	if err := os.WriteFile(path, []byte("1\n2\nNaN\n4\n"), 0o644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	output, err := runStats(path)
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	if strings.Contains(output, "NaN") && !strings.Contains(output, "invalid number") {
+		t.Errorf("NaN leaked into computed output:\n%s", output)
+	}
+	for _, want := range []string{"Count:             3", "Skipped:           1 invalid line", "Min:               1", "Max:               4"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, output)
+		}
+	}
+}
+
+// --- Number formatting: small magnitudes must not collapse to zero ---
+
+func TestFormatFloatAdaptiveDecimals(t *testing.T) {
+	tests := []struct {
+		value    float64
+		expected string
+	}{
+		{0, "0"},
+		{42, "42"},
+		{-42, "-42"},
+		{20.73, "20.73"},
+		{55.659728571, "55.6597"},
+		{0.5, "0.5"},
+		// Below the old fixed 4-decimal floor these all used to print as "0"
+		{0.00004, "0.00004"},
+		{0.00006, "0.00006"},
+		{0.000012345, "0.00001234"},
+		{-0.00004, "-0.00004"},
+		{0.0000000001234, "0.0000000001234"},
+	}
+	for _, tc := range tests {
+		if got := formatFloat(tc.value); got != tc.expected {
+			t.Errorf("formatFloat(%v): got %q, expected %q", tc.value, got, tc.expected)
+		}
+	}
+}
+
+func TestFormatFloatNeverUsesScientificNotation(t *testing.T) {
+	for _, v := range []float64{1e-12, 5e-7, 1.5e9, -3.25e-8} {
+		got := formatFloat(v)
+		if strings.ContainsAny(got, "eE") {
+			t.Errorf("formatFloat(%v) used scientific notation: %q", v, got)
+		}
+	}
+}
+
+func TestSmallMagnitudeStatsSurviveFormatting(t *testing.T) {
+	path := writeTempData(t, []float64{0.00004, 0.00006})
+	output, err := runStats(path)
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	for _, want := range []string{"Min:               0.00004", "Max:               0.00006", "Mean:              0.00005"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, output)
+		}
+	}
+}
+
+// --- Flag validation ---
+
+func TestIQRMultiplierValidation(t *testing.T) {
+	for _, k := range []string{"-1", "0"} {
+		output, err := runStats("-k", k, "test_data.txt")
+		if err == nil {
+			t.Errorf("expected error for -k %s, got none:\n%s", k, output)
+		}
+		if !strings.Contains(output, "IQR multiplier must be greater than 0") {
+			t.Errorf("expected IQR multiplier error for -k %s, got: %s", k, output)
+		}
+	}
+
+	if output, err := runStats("-k", "0.5", "test_data.txt"); err != nil {
+		t.Errorf("expected -k 0.5 to succeed: %v\n%s", err, output)
+	}
+}
+
+func TestExtraArgumentsRejected(t *testing.T) {
+	// Go's flag package stops at the first non-flag argument, so these options
+	// used to be accepted and silently ignored.
+	output, err := runStats("test_data.txt", "-z", "2.0")
+	if err == nil {
+		t.Fatalf("expected error for options after the filename, got none:\n%s", output)
+	}
+	if !strings.Contains(output, "expected at most one input file") {
+		t.Errorf("expected extra-argument error, got: %s", output)
+	}
+	if !strings.Contains(output, "options must appear before the filename") {
+		t.Errorf("expected hint about option ordering, got: %s", output)
+	}
+
+	output, err = runStats("test_data.txt", "symmetric_data.txt")
+	if err == nil {
+		t.Fatalf("expected error for two input files, got none:\n%s", output)
+	}
+}
+
+func TestVersionFlagIgnoresOtherValidation(t *testing.T) {
+	// -v is handled before flag validation, so an invalid bin count must not mask it
+	output, err := runStats("-v", "-b", "3")
+	if err != nil {
+		t.Fatalf("expected -v to succeed regardless of other flags: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "version "+PgmVersion) {
+		t.Errorf("expected version output, got: %s", output)
+	}
+}
+
+// --- Z-score reporting on degenerate data ---
+
+func TestZScoreReportedWhenStdDevIsZero(t *testing.T) {
+	stats, err := computeStats([]float64{5, 5, 5}, nil, 1.5, 16, 2.0, 0, 0)
+	if err != nil {
+		t.Fatalf("computeStats returned error: %v", err)
+	}
+	// The request is recorded even though it cannot be satisfied
+	if !floatEquals(stats.ZScoreThreshold, 2.0) {
+		t.Errorf("ZScoreThreshold: got %v, expected 2.0", stats.ZScoreThreshold)
+	}
+	if stats.ZScoreValid {
+		t.Error("ZScoreValid: got true, expected false for zero standard deviation")
+	}
+	if stats.ModZValid {
+		t.Error("ModZValid: got true, expected false for zero MAD")
+	}
+	if stats.ZScoreOutliers != nil {
+		t.Errorf("ZScoreOutliers: got %v, expected nil", stats.ZScoreOutliers)
+	}
+}
+
+func TestZScoreSectionNotSilentlyDropped(t *testing.T) {
+	path := writeTempData(t, []float64{5, 5, 5, 5})
+	output, err := runStats("-z", "2.0", path)
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "N/A - standard deviation is zero") {
+		t.Errorf("expected Z-outlier N/A line, got:\n%s", output)
+	}
+	if !strings.Contains(output, "N/A - MAD is zero") {
+		t.Errorf("expected Mod Z-outlier N/A line, got:\n%s", output)
+	}
+}
+
+// --- Custom percentiles ---
+
+func TestCustomPercentiles(t *testing.T) {
+	stats, err := computeStats(testData, []float64{10, 90, 99.9}, 1.5, 16, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("computeStats returned error: %v", err)
+	}
+	if len(stats.CustomPercentiles) != 3 {
+		t.Fatalf("CustomPercentiles: got %d entries, expected 3", len(stats.CustomPercentiles))
+	}
+
+	sorted := make([]float64, len(testData))
+	copy(sorted, testData)
+	sort.Float64s(sorted)
+	for _, p := range []float64{10, 90, 99.9} {
+		want := calculatePercentile(sorted, p/100.0)
+		if got := stats.CustomPercentiles[p]; !floatEquals(got, want) {
+			t.Errorf("CustomPercentiles[%v]: got %v, expected %v", p, got, want)
+		}
+	}
+
+	// p0 and p100 are the min and max
+	edges, err := computeStats(testData, []float64{0, 100}, 1.5, 16, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("computeStats returned error: %v", err)
+	}
+	if !floatEquals(edges.CustomPercentiles[0], edges.Min) {
+		t.Errorf("p0: got %v, expected Min %v", edges.CustomPercentiles[0], edges.Min)
+	}
+	if !floatEquals(edges.CustomPercentiles[100], edges.Max) {
+		t.Errorf("p100: got %v, expected Max %v", edges.CustomPercentiles[100], edges.Max)
+	}
+}
+
+func TestCustomPercentilesDisabled(t *testing.T) {
+	stats, err := computeStats(testData, nil, 1.5, 16, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("computeStats returned error: %v", err)
+	}
+	if stats.CustomPercentiles != nil {
+		t.Errorf("CustomPercentiles: got %v, expected nil", stats.CustomPercentiles)
+	}
+}
+
+func TestCustomPercentilesCLI(t *testing.T) {
+	output, err := runStats("-p", "10,90", "test_data.txt")
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	for _, want := range []string{"Percentile (p10):", "Percentile (p90):"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, output)
+		}
+	}
+
+	if output, err := runStats("-p", "101", "test_data.txt"); err == nil {
+		t.Errorf("expected error for out-of-range percentile, got none:\n%s", output)
+	}
+	if output, err := runStats("-p", "abc", "test_data.txt"); err == nil {
+		t.Errorf("expected error for unparseable percentile, got none:\n%s", output)
+	}
+}
+
+// --- 95% confidence interval for the mean ---
+
+func TestConfidenceInterval(t *testing.T) {
+	stats, err := computeStats(testData, nil, 1.5, 16, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("computeStats returned error: %v", err)
+	}
+	if !stats.CIValid {
+		t.Fatal("CIValid: got false, expected true")
+	}
+	// mean 51.7258 ± 1.96 * 6.0303
+	if !floatEquals(stats.CI95Lower, 51.7258-1.96*6.0303) {
+		t.Errorf("CI95Lower: got %v", stats.CI95Lower)
+	}
+	if !floatEquals(stats.CI95Upper, 51.7258+1.96*6.0303) {
+		t.Errorf("CI95Upper: got %v", stats.CI95Upper)
+	}
+	// The interval is centered on the mean and its half-width is 1.96 standard errors
+	if !floatEquals((stats.CI95Lower+stats.CI95Upper)/2, stats.Mean) {
+		t.Errorf("interval is not centered on the mean")
+	}
+	if !floatEquals((stats.CI95Upper-stats.CI95Lower)/2, ci95Z*stats.StdErr) {
+		t.Errorf("interval half-width is not 1.96 standard errors")
+	}
+}
+
+func TestConfidenceIntervalSuppressedForZeroSpread(t *testing.T) {
+	stats, err := computeStats([]float64{7, 7, 7}, nil, 1.5, 16, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("computeStats returned error: %v", err)
+	}
+	if stats.CIValid {
+		t.Error("CIValid: got true, expected false when the standard error is zero")
+	}
+
+	output, err := runStats(writeTempData(t, []float64{7, 7, 7}))
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	if strings.Contains(output, "95% CI") {
+		t.Errorf("expected no CI line for zero-spread data, got:\n%s", output)
+	}
+}
+
+// --- Histogram binning ---
+
+func TestGenerateHistogramCapsBinsToDataLength(t *testing.T) {
+	// 7 values with 20 requested bins must produce 7 bins, matching the trendline
+	data := []float64{1, 2, 3, 4, 5, 8, 9}
+	hist := generateHistogram(data, 20)
+	if got := len([]rune(hist)); got != 7 {
+		t.Errorf("expected 7 runes when bins exceed data length, got %d (%q)", got, hist)
+	}
+	trend := generateTrendline(data, 20)
+	if len([]rune(hist)) != len([]rune(trend)) {
+		t.Errorf("histogram (%d) and trendline (%d) lengths must match", len([]rune(hist)), len([]rune(trend)))
+	}
+}
+
+func TestGenerateHistogramSparseBinsAreVisible(t *testing.T) {
+	// One dominant bin plus nine bins holding a single value each. Sparse bins must
+	// not render as the same glyph as an empty bin.
+	data := make([]float64, 0, 110)
+	for i := 0; i < 100; i++ {
+		data = append(data, 0)
+	}
+	for i := 1; i <= 9; i++ {
+		data = append(data, float64(i*10))
+	}
+	data = append(data, 100)
+	sort.Float64s(data)
+
+	hist := []rune(generateHistogram(data, 11))
+	if hist[0] != '█' {
+		t.Errorf("expected a full block for the dominant bin, got %c", hist[0])
+	}
+	for i, r := range hist[1:] {
+		if r == '▁' {
+			t.Errorf("occupied bin %d rendered as the empty-bin glyph", i+1)
+		}
+	}
+}
+
+// --- Modal bin fallback for continuous data ---
+
+func TestModalBinReportedWhenNoModeExists(t *testing.T) {
+	stats, err := computeStats(symmetricTestData, nil, 1.5, 16, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("computeStats returned error: %v", err)
+	}
+	if len(stats.Mode) != 0 {
+		t.Fatalf("Mode: got %v, expected none for all-distinct data", stats.Mode)
+	}
+	if !stats.ModalBinValid {
+		t.Fatal("ModalBinValid: got false, expected true")
+	}
+	if stats.ModalBinCount < 1 {
+		t.Errorf("ModalBinCount: got %d, expected at least 1", stats.ModalBinCount)
+	}
+	if stats.ModalBinLow >= stats.ModalBinHigh {
+		t.Errorf("modal bin edges are not ordered: [%v, %v]", stats.ModalBinLow, stats.ModalBinHigh)
+	}
+	if stats.ModalBinLow < stats.Min || stats.ModalBinHigh > stats.Max+1e-9 {
+		t.Errorf("modal bin [%v, %v] falls outside the data range [%v, %v]",
+			stats.ModalBinLow, stats.ModalBinHigh, stats.Min, stats.Max)
+	}
+
+	// The reported count must match the number of values actually inside the bin
+	inside := 0
+	for _, v := range symmetricTestData {
+		if v >= stats.ModalBinLow && v < stats.ModalBinHigh {
+			inside++
+		}
+	}
+	if inside != stats.ModalBinCount {
+		t.Errorf("ModalBinCount: got %d, but %d values fall in [%v, %v)",
+			stats.ModalBinCount, inside, stats.ModalBinLow, stats.ModalBinHigh)
+	}
+}
+
+func TestModalBinSuppressedWhenModeExists(t *testing.T) {
+	stats, err := computeStats(testData, nil, 1.5, 16, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("computeStats returned error: %v", err)
+	}
+	if stats.ModalBinValid {
+		t.Error("ModalBinValid: got true, expected false when a real mode exists")
+	}
+}
+
+func TestModalBinSuppressedForZeroSpread(t *testing.T) {
+	// All identical: there is a mode, so no fallback. All distinct but only one
+	// value: nothing to bin.
+	single, err := computeStats([]float64{42}, nil, 1.5, 16, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("computeStats returned error: %v", err)
+	}
+	if single.ModalBinValid {
+		t.Error("ModalBinValid: got true, expected false for a single value")
+	}
+}
+
+func TestModalBinOutputLine(t *testing.T) {
+	output, err := runStats("symmetric_data.txt")
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "modal bin:") {
+		t.Errorf("expected modal bin on the Mode line, got:\n%s", output)
+	}
+
+	output, err = runStats("test_data.txt")
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	if strings.Contains(output, "modal bin:") {
+		t.Errorf("expected no modal bin when a mode exists, got:\n%s", output)
+	}
+}
+
+// --- Order-dependence warning ---
+
+func TestSortedInputWarningNamesEMA(t *testing.T) {
+	path := writeTempData(t, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+
+	output, err := runStats("-e", "3", path)
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "trendline, autocorrelation, and EMA reflect this sort order") {
+		t.Errorf("expected EMA named in the sort-order warning, got:\n%s", output)
+	}
+
+	// Without -e there is no EMA line, so it must not be named
+	output, err = runStats(path)
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "trendline and autocorrelation reflect this sort order") {
+		t.Errorf("expected the two-statistic warning without -e, got:\n%s", output)
+	}
+}
+
+// --- JSON output ---
+
+func TestJSONOutput(t *testing.T) {
+	output, err := runStats("-j", "-z", "2.0", "-p", "10,90", "test_data.txt")
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, output)
+	}
+
+	want := map[string]float64{
+		"count":    31,
+		"sum":      1603.5,
+		"mean":     51.7258,
+		"median":   50,
+		"stdDev":   33.5751,
+		"variance": 1127.2848,
+		"q1":       27.5,
+		"q3":       72.625,
+		"p95":      97.5,
+		"p99":      135,
+		"iqr":      45.125,
+		"skewness": 0.7271,
+		"kurtosis": 0.8884,
+		"mad":      37.065,
+		"stdErr":   6.0303,
+	}
+	for key, expected := range want {
+		v, ok := got[key].(float64)
+		if !ok {
+			t.Errorf("JSON key %q missing or not a number", key)
+			continue
+		}
+		if !floatEquals(v, expected) {
+			t.Errorf("JSON %q: got %v, expected %v", key, v, expected)
+		}
+	}
+
+	if got["version"] != PgmVersion {
+		t.Errorf("JSON version: got %v, expected %v", got["version"], PgmVersion)
+	}
+	if got["inputOrder"] != "unordered" {
+		t.Errorf("JSON inputOrder: got %v, expected unordered", got["inputOrder"])
+	}
+
+	pcts, ok := got["customPercentiles"].(map[string]any)
+	if !ok {
+		t.Fatalf("JSON customPercentiles missing: %v", got["customPercentiles"])
+	}
+	for _, key := range []string{"10", "90"} {
+		if _, ok := pcts[key]; !ok {
+			t.Errorf("JSON customPercentiles missing key %q", key)
+		}
+	}
+
+	// Outlier lists must be arrays, never null, when they were computed
+	for _, key := range []string{"outliers", "zScoreOutliers", "modZOutliers"} {
+		if _, ok := got[key].([]any); !ok {
+			t.Errorf("JSON %q: got %v, expected an array", key, got[key])
+		}
+	}
+}
+
+func TestJSONMatchesTextOutput(t *testing.T) {
+	jsonOut, err := runStats("-j", "sample_data.txt")
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, jsonOut)
+	}
+	textOut, err := runStats("sample_data.txt")
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, textOut)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(jsonOut), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	// Every JSON scalar the text output also prints must format identically
+	pairs := []struct {
+		key   string
+		label string
+	}{
+		{"sum", "Sum:"},
+		{"min", "Min:"},
+		{"max", "Max:"},
+		{"mean", "Mean:"},
+		{"median", "Median (p50):"},
+		{"stdDev", "Std Deviation:"},
+		{"variance", "Variance:"},
+		{"iqr", "IQR:"},
+	}
+	for _, p := range pairs {
+		v, ok := parsed[p.key].(float64)
+		if !ok {
+			t.Errorf("JSON key %q missing", p.key)
+			continue
+		}
+		want := p.label + " " + formatFloat(v)
+		found := false
+		for _, line := range strings.Split(textOut, "\n") {
+			if strings.HasPrefix(line, p.label) && strings.Join(strings.Fields(line), " ") == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("text output has no line matching %q", want)
+		}
+	}
+}
+
+func TestJSONUnderTrimAndLogTransform(t *testing.T) {
+	output, err := runStats("-j", "-T", "10", "test_data.txt")
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	var trimmed map[string]any
+	if err := json.Unmarshal([]byte(output), &trimmed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, output)
+	}
+	if trimmed["count"].(float64) != 25 {
+		t.Errorf("JSON count under -T: got %v, expected 25", trimmed["count"])
+	}
+	if trimmed["trimDatasetOrigN"].(float64) != 31 {
+		t.Errorf("JSON trimDatasetOrigN: got %v, expected 31", trimmed["trimDatasetOrigN"])
+	}
+	if trimmed["inputOrder"] != "" {
+		t.Errorf("JSON inputOrder under -T: got %v, expected empty", trimmed["inputOrder"])
+	}
+	if trimmed["autocorrValid"] != false {
+		t.Errorf("JSON autocorrValid under -T: got %v, expected false", trimmed["autocorrValid"])
+	}
+
+	output, err = runStats("-j", "-l", "test_data.txt")
+	if err != nil {
+		t.Fatalf("stats failed: %v\n%s", err, output)
+	}
+	var logged map[string]any
+	if err := json.Unmarshal([]byte(output), &logged); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, output)
+	}
+	if logged["logTransformed"] != true {
+		t.Errorf("JSON logTransformed: got %v, expected true", logged["logTransformed"])
+	}
+	if logged["geoMeanValid"] != false {
+		t.Errorf("JSON geoMeanValid under -l: got %v, expected false", logged["geoMeanValid"])
 	}
 }

--- a/verify_stats.py
+++ b/verify_stats.py
@@ -1,0 +1,944 @@
+#!/usr/bin/env python3
+"""Third verification layer for the go-stats-calculator program.
+
+This script reimplements every statistic the Go program reports, using only the
+Python standard library, and compares its own results against the program's JSON
+output (``stats -j``). It complements verify_stats.sh, which uses bc for
+arbitrary-precision arithmetic on a single dataset: this script trades bc's
+precision for far broader coverage, reaching the histogram, trendline, symmetry,
+modal bin, and flag interactions that are impractical to express in bc.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any, Sequence
+
+BLOCKS: str = "▁▂▃▄▅▆▇█"
+
+# Fields rendered as block glyphs, compared with a one-level tolerance.
+GLYPH_KEYS: frozenset[str] = frozenset({"histogram", "trendline"})
+MAD_SCALE: float = 1.4826
+MOD_Z_SCALE: float = 0.6745
+CI95_Z: float = 1.96
+
+# The same 31-value fixture used by stats_test.go and verify_stats.sh.
+TEST_DATA: list[float] = [
+    5, 10, 15.5, 20, 25.00, 30, 35.0, 40, 45, 50,
+    55, 60, 65, 70, 75.25, 80, 85, 90, 95, 100,
+    12.5, 37.5, 62.50, 87.5, 50, 50, 50, 3, 150, 7.75, 42.0,
+]
+
+# 20 disjoint pairs each summing to 1000, symmetric about 500.
+SYMMETRIC_DATA: list[float] = [
+    612, 137, 827, 495, 958, 264, 709, 19, 882, 455,
+    349, 736, 88, 981, 545, 233, 61, 694, 42, 767,
+    388, 118, 912, 651, 306, 994, 173, 588, 505, 377,
+    863, 220, 939, 6, 623, 780, 151, 849, 291, 412,
+]
+
+# A tight cluster with two adjacent outliers that mask each other's z-scores.
+MASKING_DATA: list[float] = [10, 10.2, 10.5, 10.8, 11, 11.2, 11.5, 11.8, 12, 12.3, 50, 52]
+
+
+def round_half_up(value: float) -> int:
+    """Round a non-negative value half away from zero, matching Go's math.Round.
+
+    Args:
+        value: The value to round. Must be non-negative.
+
+    Returns:
+        The rounded value as an integer.
+    """
+    return int(math.floor(value + 0.5))
+
+
+def percentile(sorted_values: Sequence[float], fraction: float) -> float:
+    """Compute a percentile using linear interpolation between order statistics.
+
+    This is the R-7 method: rank = p * (n - 1), interpolating between the
+    surrounding values.
+
+    Args:
+        sorted_values: Values in ascending order.
+        fraction: The percentile expressed as a fraction between 0.0 and 1.0.
+
+    Returns:
+        The interpolated percentile value, or 0.0 for empty input.
+    """
+    n = len(sorted_values)
+    if n == 0:
+        return 0.0
+    if n == 1:
+        return float(sorted_values[0])
+    rank = fraction * (n - 1)
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return float(sorted_values[int(rank)])
+    weight = rank - lower
+    return sorted_values[int(lower)] * (1 - weight) + sorted_values[int(upper)] * weight
+
+
+def median_of(values: Sequence[float]) -> float:
+    """Return the interpolated median of an unsorted sequence.
+
+    Args:
+        values: The values to summarize.
+
+    Returns:
+        The median value.
+    """
+    return percentile(sorted(values), 0.50)
+
+
+def bin_counts(sorted_values: Sequence[float], num_bins: int) -> tuple[list[int], float, float]:
+    """Bucket sorted values into equal-width bins spanning the data range.
+
+    The bin count is capped at the number of values so bins never outnumber
+    observations.
+
+    Args:
+        sorted_values: Values in ascending order.
+        num_bins: The requested number of bins.
+
+    Returns:
+        A tuple of (bin counts, minimum value, bin width). The counts list is
+        empty when the data has fewer than two values or no spread.
+    """
+    n = len(sorted_values)
+    if n < 2:
+        return [], 0.0, 0.0
+    low = sorted_values[0]
+    high = sorted_values[-1]
+    if low == high:
+        return [], 0.0, 0.0
+    num_bins = min(num_bins, n)
+    width = (high - low) / num_bins
+    bins = [0] * num_bins
+    for value in sorted_values:
+        index = int((value - low) / width)
+        if index >= num_bins:
+            index = num_bins - 1
+        bins[index] += 1
+    return bins, low, width
+
+
+def histogram(sorted_values: Sequence[float], num_bins: int) -> str:
+    """Render a single-line Unicode histogram of the data distribution.
+
+    Occupied bins are floored one level above empty so that a sparse bin is
+    visually distinct from a bin holding nothing.
+
+    Args:
+        sorted_values: Values in ascending order.
+        num_bins: The requested number of bins.
+
+    Returns:
+        The histogram string, or an empty string when the data cannot be binned.
+    """
+    bins, _, _ = bin_counts(sorted_values, num_bins)
+    if not bins:
+        return ""
+    highest = max(bins)
+    glyphs = []
+    for count in bins:
+        if count == 0:
+            glyphs.append(BLOCKS[0])
+            continue
+        level = (count * 7) // highest
+        glyphs.append(BLOCKS[max(level, 1)])
+    return "".join(glyphs)
+
+
+def trendline(values: Sequence[float], num_bins: int) -> str:
+    """Render a single-line Unicode trendline of values in their input order.
+
+    Args:
+        values: The values in their original order.
+        num_bins: The requested number of chunks.
+
+    Returns:
+        The trendline string, or an empty string when the data has no spread.
+    """
+    n = len(values)
+    if n < 2:
+        return ""
+    low = min(values)
+    high = max(values)
+    if low == high:
+        return ""
+    num_bins = min(num_bins, n)
+    step = n / num_bins
+    glyphs = []
+    for i in range(num_bins):
+        start = round_half_up(i * step)
+        end = min(round_half_up((i + 1) * step), n)
+        if end <= start:
+            end = start + 1
+        average = sum(values[start:end]) / (end - start)
+        normalized = (average - low) / (high - low)
+        level = min(max(round_half_up(normalized * 7), 0), 7)
+        glyphs.append(BLOCKS[level])
+    return "".join(glyphs)
+
+
+def detect_symmetry(sorted_values: Sequence[float]) -> tuple[bool, float, int]:
+    """Report whether sorted data mirrors itself about a center value.
+
+    Args:
+        sorted_values: Values in ascending order.
+
+    Returns:
+        A tuple of (is symmetric, center, pair count). Center and pair count are
+        meaningful only when the first element is True.
+    """
+    n = len(sorted_values)
+    if n < 3:
+        return False, 0.0, 0
+    center = (sorted_values[0] + sorted_values[-1]) / 2
+    scale = max(abs(sorted_values[0]), abs(sorted_values[-1]))
+    tolerance = 1e-9 * max(1.0, scale)
+    index = 0
+    while index <= n - 1 - index:
+        if abs(sorted_values[index] + sorted_values[n - 1 - index] - 2 * center) > tolerance:
+            return False, 0.0, 0
+        index += 1
+    return True, center, n // 2
+
+
+def detect_monotonicity(values: Sequence[float]) -> str:
+    """Classify the input order of a sequence.
+
+    Args:
+        values: The values in their original order.
+
+    Returns:
+        One of "ascending", "descending", "constant", or "unordered". Ascending
+        and descending are non-strict, so ties are allowed.
+    """
+    non_decreasing = all(values[i] >= values[i - 1] for i in range(1, len(values)))
+    non_increasing = all(values[i] <= values[i - 1] for i in range(1, len(values)))
+    if non_decreasing and non_increasing:
+        return "constant"
+    if non_decreasing:
+        return "ascending"
+    if non_increasing:
+        return "descending"
+    return "unordered"
+
+
+def autocorrelation(values: Sequence[float], mean: float) -> float:
+    """Compute the lag-1 autocorrelation of values in their input order.
+
+    Args:
+        values: The values in their original order.
+        mean: The arithmetic mean of the values.
+
+    Returns:
+        The lag-1 autocorrelation, or 0.0 for fewer than three values or zero variance.
+    """
+    n = len(values)
+    if n < 3:
+        return 0.0
+    denominator = sum((v - mean) ** 2 for v in values)
+    if denominator == 0:
+        return 0.0
+    numerator = sum((values[i] - mean) * (values[i + 1] - mean) for i in range(n - 1))
+    return numerator / denominator
+
+
+def exponential_moving_average(values: Sequence[float], span: int) -> float:
+    """Compute the final exponential moving average for a given span.
+
+    Args:
+        values: The values in their original order.
+        span: The EMA span, which sets the smoothing factor to 2 / (span + 1).
+
+    Returns:
+        The final EMA value.
+    """
+    alpha = 2.0 / (span + 1.0)
+    ema = values[0]
+    for value in values[1:]:
+        ema = alpha * value + (1 - alpha) * ema
+    return ema
+
+
+def trimmed_mean(sorted_values: Sequence[float], percent: float) -> float:
+    """Compute the mean after removing a percentage of values from each tail.
+
+    Args:
+        sorted_values: Values in ascending order.
+        percent: The percentage to remove from each tail, between 0 and 50.
+
+    Returns:
+        The trimmed mean.
+
+    Raises:
+        ValueError: If trimming would leave no values.
+    """
+    n = len(sorted_values)
+    trim_count = math.floor(n * percent / 100.0)
+    remaining = n - 2 * trim_count
+    if remaining < 1:
+        raise ValueError(f"dataset too small ({n} values) to trim {percent}% from each end")
+    kept = sorted_values[trim_count:n - trim_count]
+    return sum(kept) / len(kept)
+
+
+class Reference:
+    """An independent reimplementation of every statistic the program reports.
+
+    The class computes each value from the raw input using only the standard
+    library, so a shared bug in the Go implementation cannot hide behind a shared
+    helper. Its as_dict output uses the same field names as the program's JSON.
+    """
+
+    def __init__(self, values: Sequence[float], num_bins: int = 16, iqr_multiplier: float = 1.5, z_threshold: float = 0.0, ema_span: int = 0, trim_mean_pct: float = 0.0) -> None:
+        """Compute all statistics for the given values.
+
+        Args:
+            values: The input values in their original order.
+            num_bins: Bin count for the histogram and trendline.
+            iqr_multiplier: Multiplier for IQR-based outlier fences.
+            z_threshold: Z-score threshold, or 0 to disable z-score detection.
+            ema_span: EMA span, or 0 to disable.
+            trim_mean_pct: Trimmed-mean percentage, or 0 to disable.
+        """
+        self.values = list(values)
+        self.num_bins = num_bins
+        self.iqr_multiplier = iqr_multiplier
+        self.z_threshold = z_threshold
+        self.ema_span = ema_span
+        self.trim_mean_pct = trim_mean_pct
+        self.sorted = sorted(self.values)
+        self.count = len(self.values)
+        self._compute()
+
+    def _compute(self) -> None:
+        """Populate every derived statistic. Called once from the constructor."""
+        n = self.count
+        self.total = sum(self.values)
+        self.mean = self.total / n
+
+        if n > 1:
+            self.variance = sum((v - self.mean) ** 2 for v in self.values) / (n - 1)
+            self.std_dev = math.sqrt(self.variance)
+        else:
+            self.variance = 0.0
+            self.std_dev = 0.0
+
+        self.std_err = self.std_dev / math.sqrt(n)
+        self.ci_valid = n > 1 and self.std_err > 0
+        self.ci_lower = self.mean - CI95_Z * self.std_err if self.ci_valid else 0.0
+        self.ci_upper = self.mean + CI95_Z * self.std_err if self.ci_valid else 0.0
+
+        self.minimum = self.sorted[0]
+        self.maximum = self.sorted[-1]
+        self.median = percentile(self.sorted, 0.50)
+        self.q1 = percentile(self.sorted, 0.25)
+        self.q3 = percentile(self.sorted, 0.75)
+        self.p95 = percentile(self.sorted, 0.95)
+        self.p99 = percentile(self.sorted, 0.99)
+        self.iqr = self.q3 - self.q1
+
+        deviations = sorted(abs(v - self.median) for v in self.values)
+        self.mad = MAD_SCALE * percentile(deviations, 0.50)
+
+        self.geo_mean_valid = self.minimum > 0
+        self.geometric_mean = math.exp(sum(math.log(v) for v in self.values) / n) if self.geo_mean_valid else 0.0
+
+        frequencies: dict[float, int] = {}
+        for value in self.values:
+            frequencies[value] = frequencies.get(value, 0) + 1
+        self.distinct = len(frequencies)
+        highest = max(frequencies.values())
+        self.mode = sorted(v for v, f in frequencies.items() if f == highest) if highest > 1 else []
+
+        self.modal_bin_valid = False
+        self.modal_bin_low = 0.0
+        self.modal_bin_high = 0.0
+        self.modal_bin_count = 0
+        if not self.mode:
+            bins, low, width = bin_counts(self.sorted, self.num_bins)
+            if bins:
+                best = bins.index(max(bins))
+                self.modal_bin_valid = True
+                self.modal_bin_low = low + best * width
+                self.modal_bin_high = self.modal_bin_low + width
+                self.modal_bin_count = bins[best]
+
+        lower_fence = self.q1 - self.iqr_multiplier * self.iqr
+        upper_fence = self.q3 + self.iqr_multiplier * self.iqr
+        self.outliers = sorted(v for v in self.values if v < lower_fence or v > upper_fence)
+
+        self.z_valid = self.z_threshold > 0 and self.std_dev > 0
+        self.mod_z_valid = self.z_threshold > 0 and self.mad > 0
+        self.z_outliers: list[float] = []
+        self.mod_z_outliers: list[float] = []
+        if self.z_valid:
+            self.z_outliers = sorted(v for v in self.values if abs((v - self.mean) / self.std_dev) > self.z_threshold)
+        if self.mod_z_valid:
+            raw_mad = self.mad / MAD_SCALE
+            self.mod_z_outliers = sorted(v for v in self.values if abs(MOD_Z_SCALE * (v - self.median) / raw_mad) > self.z_threshold)
+
+        self.skewness = self._skewness()
+        self.kurtosis = self._kurtosis()
+        self.is_symmetric, self.symmetry_center, self.symmetry_pairs = detect_symmetry(self.sorted)
+        self.has_negative = any(v < 0 for v in self.values)
+        self.cv_valid = abs(self.mean) >= 1e-10
+        self.cv = (self.std_dev / abs(self.mean)) * 100 if self.cv_valid else 0.0
+
+        self.histogram = histogram(self.sorted, self.num_bins)
+        self.trendline = trendline(self.values, self.num_bins)
+        self.autocorr_valid = n >= 3 and self.std_dev > 0
+        self.autocorrelation = autocorrelation(self.values, self.mean) if self.autocorr_valid else 0.0
+        self.input_order = detect_monotonicity(self.values) if n >= 2 else ""
+        self.ema = exponential_moving_average(self.values, self.ema_span) if self.ema_span >= 2 else 0.0
+        self.trimmed_mean = trimmed_mean(self.sorted, self.trim_mean_pct) if self.trim_mean_pct > 0 else 0.0
+
+    def _skewness(self) -> float:
+        """Compute the adjusted Fisher-Pearson standardized moment coefficient.
+
+        Returns:
+            The sample skewness, or 0.0 when it is undefined.
+        """
+        n = self.count
+        if n < 3 or self.std_dev == 0:
+            return 0.0
+        cubed = sum((v - self.mean) ** 3 for v in self.values)
+        return (n / ((n - 1) * (n - 2))) * (cubed / self.std_dev ** 3)
+
+    def _kurtosis(self) -> float:
+        """Compute the sample excess kurtosis.
+
+        Returns:
+            The excess kurtosis, or 0.0 when it is undefined.
+        """
+        n = self.count
+        if n < 4 or self.std_dev == 0:
+            return 0.0
+        fourth = sum(((v - self.mean) / self.std_dev) ** 4 for v in self.values)
+        return (n * (n + 1)) / ((n - 1) * (n - 2) * (n - 3)) * fourth - 3 * (n - 1) ** 2 / ((n - 2) * (n - 3))
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the statistics keyed by the program's JSON field names.
+
+        Returns:
+            A mapping from JSON field name to the independently computed value.
+        """
+        return {
+            "count": self.count,
+            "distinct": self.distinct,
+            "duplicatePct": (self.count - self.distinct) / self.count * 100,
+            "sum": self.total,
+            "mean": self.mean,
+            "stdErr": self.std_err,
+            "ci95Lower": self.ci_lower,
+            "ci95Upper": self.ci_upper,
+            "ciValid": self.ci_valid,
+            "geometricMean": self.geometric_mean,
+            "geoMeanValid": self.geo_mean_valid,
+            "median": self.median,
+            "mode": self.mode,
+            "modalBinLow": self.modal_bin_low,
+            "modalBinHigh": self.modal_bin_high,
+            "modalBinCount": self.modal_bin_count,
+            "modalBinValid": self.modal_bin_valid,
+            "min": self.minimum,
+            "max": self.maximum,
+            "stdDev": self.std_dev,
+            "variance": self.variance,
+            "mad": self.mad,
+            "q1": self.q1,
+            "q3": self.q3,
+            "p95": self.p95,
+            "p99": self.p99,
+            "iqr": self.iqr,
+            "iqrMultiplier": self.iqr_multiplier,
+            "outliers": self.outliers,
+            "zScoreThreshold": self.z_threshold,
+            "zScoreValid": self.z_valid,
+            "modZValid": self.mod_z_valid,
+            "skewness": self.skewness,
+            "kurtosis": self.kurtosis,
+            "isSymmetric": self.is_symmetric,
+            "symmetryCenter": self.symmetry_center,
+            "symmetryPairs": self.symmetry_pairs,
+            "cv": self.cv,
+            "cvValid": self.cv_valid,
+            "hasNegativeData": self.has_negative,
+            "histogram": self.histogram,
+            "trendline": self.trendline,
+            "autocorrelation": self.autocorrelation,
+            "autocorrValid": self.autocorr_valid,
+            "inputOrder": self.input_order,
+            "ema": self.ema,
+            "emaSpan": self.ema_span,
+            "trimmedMean": self.trimmed_mean,
+            "trimmedMeanPct": self.trim_mean_pct,
+        }
+
+
+class Runner:
+    """Invokes the stats program and returns parsed results."""
+
+    def __init__(self, binary: str | None = None) -> None:
+        """Locate the program to test.
+
+        Args:
+            binary: Explicit path to the stats binary, or None to auto-detect.
+        """
+        if binary:
+            self.command = [binary]
+        elif os.access("./stats", os.X_OK):
+            self.command = ["./stats"]
+        else:
+            self.command = ["go", "run", "."]
+
+    def run(self, values: Sequence[float] | None, *args: str, raw_input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+        """Run the program against a temporary data file.
+
+        Args:
+            values: Values to write one per line, or None when raw_input_text is used.
+            *args: Command-line options to pass before the filename.
+            raw_input_text: Exact file contents, bypassing float formatting.
+
+        Returns:
+            The completed process, including stdout, stderr, and return code.
+        """
+        text = raw_input_text if raw_input_text is not None else "\n".join(repr(v) for v in (values or [])) + "\n"
+        handle = tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False)
+        try:
+            handle.write(text)
+            handle.close()
+            return subprocess.run([*self.command, *args, handle.name], capture_output=True, text=True)
+        finally:
+            os.unlink(handle.name)
+
+    def run_json(self, values: Sequence[float] | None, *args: str, raw_input_text: str | None = None) -> dict[str, Any]:
+        """Run the program with -j and parse its JSON output.
+
+        Args:
+            values: Values to write one per line, or None when raw_input_text is used.
+            *args: Command-line options to pass before the filename.
+            raw_input_text: Exact file contents, bypassing float formatting.
+
+        Returns:
+            The parsed JSON object.
+
+        Raises:
+            RuntimeError: If the program exits non-zero or emits invalid JSON.
+        """
+        result = self.run(values, "-j", *args, raw_input_text=raw_input_text)
+        if result.returncode != 0:
+            raise RuntimeError(f"stats exited {result.returncode}: {result.stderr.strip()}")
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"stats emitted invalid JSON: {exc}") from exc
+
+
+class Verifier:
+    """Accumulates pass and fail results and prints a report."""
+
+    def __init__(self, tolerance: float = 1e-9) -> None:
+        """Initialize an empty result set.
+
+        Args:
+            tolerance: Relative and absolute tolerance for float comparisons.
+        """
+        self.tolerance = tolerance
+        self.passed = 0
+        self.failures: list[str] = []
+
+    def check(self, description: str, actual: Any, expected: Any) -> None:
+        """Compare one value and record the outcome.
+
+        Floats are compared with the configured tolerance; everything else must
+        match exactly.
+
+        Args:
+            description: Human-readable name for the check.
+            actual: The value reported by the program.
+            expected: The independently computed value.
+        """
+        if isinstance(expected, float) or isinstance(actual, float):
+            ok = isinstance(actual, (int, float)) and math.isclose(float(actual), float(expected), rel_tol=self.tolerance, abs_tol=self.tolerance)
+        elif isinstance(expected, list):
+            ok = isinstance(actual, list) and len(actual) == len(expected) and all(math.isclose(float(a), float(e), rel_tol=self.tolerance, abs_tol=self.tolerance) for a, e in zip(actual, expected))
+        else:
+            ok = actual == expected
+        if ok:
+            self.passed += 1
+        else:
+            self.failures.append(f"{description}: got {actual!r}, expected {expected!r}")
+
+    def check_glyphs(self, description: str, actual: Any, expected: str) -> None:
+        """Compare two block-glyph strings, tolerating a one-level difference.
+
+        A chunk average can land exactly on a rounding boundary, where a one-ulp
+        difference between Go's and Python's math libraries flips the chosen block.
+        Differences of two or more levels still fail, so real scaling or ordering
+        errors are caught.
+
+        Args:
+            description: Human-readable name for the check.
+            actual: The glyph string reported by the program.
+            expected: The independently rendered glyph string.
+        """
+        if not isinstance(actual, str) or len(actual) != len(expected):
+            self.failures.append(f"{description}: got {actual!r}, expected {expected!r}")
+            return
+        for index, (got, want) in enumerate(zip(actual, expected)):
+            if got not in BLOCKS or want not in BLOCKS:
+                self.failures.append(f"{description}: non-block character at {index} in {actual!r}")
+                return
+            if abs(BLOCKS.index(got) - BLOCKS.index(want)) > 1:
+                self.failures.append(f"{description}: position {index} differs by more than one level ({got} vs {want}) in {actual!r} vs {expected!r}")
+                return
+        self.passed += 1
+
+    def check_true(self, description: str, condition: bool) -> None:
+        """Record a boolean assertion.
+
+        Args:
+            description: Human-readable name for the check.
+            condition: The assertion result.
+        """
+        if condition:
+            self.passed += 1
+        else:
+            self.failures.append(description)
+
+    def section(self, title: str) -> None:
+        """Print a section heading.
+
+        Args:
+            title: The heading text.
+        """
+        print(f"\n--- {title} ---")
+
+    def report(self) -> int:
+        """Print the summary and return a process exit code.
+
+        Returns:
+            0 when every check passed, otherwise 1.
+        """
+        print()
+        print("=" * 46)
+        if not self.failures:
+            print(f"Verification complete. All {self.passed} checks passed.")
+            print("=" * 46)
+            return 0
+        print(f"Verification FAILED. {len(self.failures)} of {self.passed + len(self.failures)} checks did not match:")
+        for failure in self.failures:
+            print(f"  {failure}")
+        print("=" * 46)
+        return 1
+
+
+def compare_dataset(verifier: Verifier, runner: Runner, name: str, values: Sequence[float], *args: str, **reference_kwargs: Any) -> None:
+    """Compare every shared field between the reference and the program.
+
+    Args:
+        verifier: The result accumulator.
+        runner: The program runner.
+        name: Label used to prefix each check description.
+        values: The dataset to analyze.
+        *args: Command-line options passed to the program.
+        **reference_kwargs: Keyword arguments forwarded to Reference.
+    """
+    verifier.section(f"{name} ({' '.join(args) if args else 'no options'})")
+    payload = runner.run_json(values, *args)
+    expected = Reference(values, **reference_kwargs).as_dict()
+    for key, want in expected.items():
+        if key in GLYPH_KEYS and want:
+            verifier.check_glyphs(f"{name}.{key}", payload.get(key), want)
+        else:
+            verifier.check(f"{name}.{key}", payload.get(key), want)
+    print(f"compared {len(expected)} fields against {len(values)} values")
+
+
+def verify_flag_behavior(verifier: Verifier, runner: Runner) -> None:
+    """Check flag validation, mutual exclusion, and degenerate-input reporting.
+
+    Args:
+        verifier: The result accumulator.
+        runner: The program runner.
+    """
+    verifier.section("Flag validation and mutual exclusion")
+
+    rejected = [
+        ("-k 0 is rejected", ("-k", "0"), "greater than 0"),
+        ("-k -1 is rejected", ("-k", "-1"), "greater than 0"),
+        ("-b 3 is rejected", ("-b", "3"), "between 5 and 50"),
+        ("-b 99 is rejected", ("-b", "99"), "between 5 and 50"),
+        ("-z 0.5 is rejected", ("-z", "0.5"), ">= 1.0"),
+        ("-e 1 is rejected", ("-e", "1"), ">= 2"),
+        ("-t 60 is rejected", ("-t", "60"), "between 0 and 50"),
+        ("-T 60 is rejected", ("-T", "60"), "between 0 and 50"),
+        ("-t with -T is rejected", ("-t", "10", "-T", "10"), "mutually exclusive"),
+        ("-e with -T is rejected", ("-e", "5", "-T", "10"), "mutually exclusive"),
+        ("-p 101 is rejected", ("-p", "101"), "between 0 and 100"),
+        ("-p abc is rejected", ("-p", "abc"), "invalid percentile"),
+    ]
+    for description, args, fragment in rejected:
+        result = runner.run(TEST_DATA, *args)
+        verifier.check_true(description, result.returncode != 0 and fragment in result.stderr)
+        print(f"  {description}")
+
+    # Options placed after the filename used to be parsed away and silently ignored
+    result = runner.run(TEST_DATA, "-z", "2.0")
+    verifier.check_true("options after the filename are rejected", result.returncode == 0)
+    trailing = subprocess.run([*runner.command, "test_data.txt", "-z", "2.0"], capture_output=True, text=True)
+    verifier.check_true("trailing options are rejected", trailing.returncode != 0 and "expected at most one input file" in trailing.stderr)
+    two_files = subprocess.run([*runner.command, "test_data.txt", "symmetric_data.txt"], capture_output=True, text=True)
+    verifier.check_true("two input files are rejected", two_files.returncode != 0)
+    print("  argument handling")
+
+
+def verify_input_sanitation(verifier: Verifier, runner: Runner) -> None:
+    """Check that non-finite and unparseable input is rejected, not absorbed.
+
+    Args:
+        verifier: The result accumulator.
+        runner: The program runner.
+    """
+    verifier.section("Input sanitation")
+
+    payload = runner.run_json(None, raw_input_text="10\n\nabc\n20\n\nNaN\n30\nInf\n-Inf\n+Inf\n")
+    verifier.check("valid values are kept", payload["count"], 3)
+    verifier.check("blank lines are not counted as skipped", payload["skippedLines"], 5)
+    verifier.check("sum is unpoisoned", payload["sum"], 60.0)
+    verifier.check("min is unpoisoned", payload["min"], 10.0)
+    verifier.check("max is unpoisoned", payload["max"], 30.0)
+
+    for key, value in payload.items():
+        if isinstance(value, float):
+            verifier.check_true(f"{key} is finite", math.isfinite(value))
+    print(f"  every numeric field finite across {len(payload)} keys")
+
+
+def verify_formatting(verifier: Verifier, runner: Runner) -> None:
+    """Check that small magnitudes survive text formatting without scientific notation.
+
+    Args:
+        verifier: The result accumulator.
+        runner: The program runner.
+    """
+    verifier.section("Text formatting of small magnitudes")
+
+    tiny = [0.00004, 0.00006]
+    text = runner.run(tiny).stdout
+    for fragment in ("0.00004", "0.00006", "0.00005"):
+        verifier.check_true(f"{fragment} appears in the output", fragment in text)
+    verifier.check_true("no scientific notation in output", "e-0" not in text and "E-0" not in text)
+
+    # The bare value 0 must never stand in for a non-zero statistic
+    for line in text.splitlines():
+        label, separator, value = line.partition(":")
+        if separator and value.strip() == "0" and label.strip() in ("Min", "Max", "Mean", "Median (p50)", "Sum"):
+            verifier.check_true(f"{label.strip()} did not collapse to 0", False)
+    print("  small-magnitude statistics preserved")
+
+
+def verify_trim_dataset(verifier: Verifier, runner: Runner) -> None:
+    """Check that -T recomputes every statistic on the trimmed data.
+
+    Args:
+        verifier: The result accumulator.
+        runner: The program runner.
+    """
+    verifier.section("Trim dataset (-T 10)")
+
+    payload = runner.run_json(TEST_DATA, "-T", "10")
+    trim_count = math.floor(len(TEST_DATA) * 10 / 100)
+    trimmed = sorted(TEST_DATA)[trim_count:len(TEST_DATA) - trim_count]
+    expected = Reference(trimmed).as_dict()
+
+    # Order-aware statistics are artifacts of the -T sort and must be suppressed
+    verifier.check("trendline suppressed", payload["trendline"], "")
+    verifier.check("inputOrder suppressed", payload["inputOrder"], "")
+    verifier.check("autocorrValid false", payload["autocorrValid"], False)
+    verifier.check("trimDatasetOrigN", payload["trimDatasetOrigN"], len(TEST_DATA))
+    verifier.check("trimDatasetPct", payload["trimDatasetPct"], 10.0)
+
+    skip = {"trendline", "inputOrder", "autocorrValid", "autocorrelation"}
+    for key, want in expected.items():
+        if key in skip:
+            continue
+        if key in GLYPH_KEYS and want:
+            verifier.check_glyphs(f"trimmed.{key}", payload.get(key), want)
+        else:
+            verifier.check(f"trimmed.{key}", payload.get(key), want)
+
+    text = runner.run(TEST_DATA, "-T", "10").stdout
+    verifier.check_true("header shows before and after counts", "31 → 25 values" in text)
+    verifier.check_true("footnote present", "all statistics above are computed on the trimmed dataset" in text)
+    starred = [line for line in text.splitlines() if ":" in line and line.split(":", 1)[0].endswith("*")]
+    verifier.check_true("no starred labels remain", not starred)
+    print(f"  compared {len(expected) - len(skip)} fields on the trimmed dataset")
+
+
+def verify_log_transform(verifier: Verifier, runner: Runner) -> None:
+    """Check that -l computes every statistic in log space.
+
+    Args:
+        verifier: The result accumulator.
+        runner: The program runner.
+    """
+    verifier.section("Log transform (-l)")
+
+    payload = runner.run_json(TEST_DATA, "-l")
+    expected = Reference([math.log(v) for v in TEST_DATA]).as_dict()
+    for key, want in expected.items():
+        # The geometric mean is deliberately suppressed under -l
+        if key in ("geometricMean", "geoMeanValid"):
+            continue
+        if key in GLYPH_KEYS and want:
+            verifier.check_glyphs(f"log.{key}", payload.get(key), want)
+        else:
+            verifier.check(f"log.{key}", payload.get(key), want)
+    verifier.check("geoMeanValid suppressed under -l", payload["geoMeanValid"], False)
+    verifier.check("logTransformed flag set", payload["logTransformed"], True)
+
+    rejected = runner.run([1.0, 2.0, 0.0, 4.0], "-l")
+    verifier.check_true("non-positive input is rejected", rejected.returncode != 0 and "requires all positive values" in rejected.stderr)
+    print(f"  compared {len(expected) - 2} fields in log space")
+
+
+def verify_custom_percentiles(verifier: Verifier, runner: Runner) -> None:
+    """Check the -p flag against independently interpolated percentiles.
+
+    Args:
+        verifier: The result accumulator.
+        runner: The program runner.
+    """
+    verifier.section("Custom percentiles (-p)")
+
+    requested = [0.0, 10.0, 33.3, 90.0, 99.9, 100.0]
+    payload = runner.run_json(TEST_DATA, "-p", ",".join(str(p) for p in requested))
+    ordered = sorted(TEST_DATA)
+    reported = payload.get("customPercentiles", {})
+    verifier.check("all requested percentiles reported", len(reported), len(requested))
+    for p in requested:
+        key = str(int(p)) if p == int(p) else str(p)
+        verifier.check(f"p{p}", reported.get(key), percentile(ordered, p / 100.0))
+    verifier.check("p0 equals the minimum", reported.get("0"), min(TEST_DATA))
+    verifier.check("p100 equals the maximum", reported.get("100"), max(TEST_DATA))
+    print(f"  verified {len(requested)} custom percentiles")
+
+
+def verify_masking(verifier: Verifier, runner: Runner) -> None:
+    """Check that modified z-scores catch outliers that classic z-scores mask.
+
+    Args:
+        verifier: The result accumulator.
+        runner: The program runner.
+    """
+    verifier.section("Z-score masking (-z 2.5)")
+
+    payload = runner.run_json(MASKING_DATA, "-z", "2.5")
+    verifier.check("classic z-scores are masked", payload["zScoreOutliers"], [])
+    verifier.check("modified z-scores catch both", payload["modZOutliers"], [50.0, 52.0])
+    verifier.check("IQR method also catches both", payload["outliers"], [50.0, 52.0])
+
+    # Degenerate data must report the threshold and mark the result invalid,
+    # rather than dropping the section entirely
+    flat = runner.run_json([5.0, 5.0, 5.0, 5.0], "-z", "2.0")
+    verifier.check("threshold recorded for flat data", flat["zScoreThreshold"], 2.0)
+    verifier.check("zScoreValid false for flat data", flat["zScoreValid"], False)
+    verifier.check("modZValid false for flat data", flat["modZValid"], False)
+    flat_text = runner.run([5.0, 5.0, 5.0, 5.0], "-z", "2.0").stdout
+    verifier.check_true("flat data reports N/A rather than nothing", "N/A - standard deviation is zero" in flat_text)
+    print("  masking and degenerate-input behavior")
+
+
+def verify_bin_counts(verifier: Verifier, runner: Runner) -> None:
+    """Check histogram and trendline rendering across bin counts.
+
+    Args:
+        verifier: The result accumulator.
+        runner: The program runner.
+    """
+    verifier.section("Histogram and trendline binning")
+
+    for bins in (5, 8, 16, 32, 50):
+        payload = runner.run_json(TEST_DATA, "-b", str(bins))
+        expected_bins = min(bins, len(TEST_DATA))
+        verifier.check(f"histogram length at -b {bins}", len(payload["histogram"]), expected_bins)
+        verifier.check(f"trendline length at -b {bins}", len(payload["trendline"]), expected_bins)
+        verifier.check_glyphs(f"histogram content at -b {bins}", payload["histogram"], histogram(sorted(TEST_DATA), bins))
+        verifier.check_glyphs(f"trendline content at -b {bins}", payload["trendline"], trendline(TEST_DATA, bins))
+
+    # Bins may never outnumber observations, or the two lines stop aligning
+    short = [1.0, 5.0, 2.0, 8.0, 3.0, 9.0, 4.0]
+    payload = runner.run_json(short, "-b", "20")
+    verifier.check("histogram capped to data length", len(payload["histogram"]), len(short))
+    verifier.check("trendline capped to data length", len(payload["trendline"]), len(short))
+
+    # A bin holding one value must not render as the empty-bin glyph
+    sparse = [0.0] * 100 + [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0]
+    payload = runner.run_json(sparse, "-b", "11")
+    verifier.check_true("sparse bins are visible", BLOCKS[0] not in payload["histogram"])
+    print("  bin counts, capping, and sparse-bin visibility")
+
+
+def main() -> int:
+    """Run every verification scenario and report the result.
+
+    Returns:
+        A process exit code: 0 when all checks pass, otherwise 1.
+    """
+    parser = argparse.ArgumentParser(description="Independently verify the go-stats-calculator program using pure Python.")
+    parser.add_argument("--binary", default=None, help="path to the stats binary (default: ./stats, else 'go run .')")
+    parser.add_argument("--tolerance", type=float, default=1e-9, help="relative and absolute float comparison tolerance")
+    arguments = parser.parse_args()
+
+    if arguments.binary is None and not os.access("./stats", os.X_OK) and shutil.which("go") is None:
+        print("Error: neither ./stats nor the go command is available", file=sys.stderr)
+        return 1
+
+    runner = Runner(arguments.binary)
+    verifier = Verifier(arguments.tolerance)
+
+    print("=" * 46)
+    print("Independent Verification of Stats Calculator")
+    print("Pure Python reimplementation vs. stats -j output")
+    print("=" * 46)
+
+    compare_dataset(verifier, runner, "testData", TEST_DATA, "-z", "2.0", z_threshold=2.0)
+    compare_dataset(verifier, runner, "symmetric", SYMMETRIC_DATA)
+    compare_dataset(verifier, runner, "masking", MASKING_DATA, "-z", "2.5", z_threshold=2.5)
+    compare_dataset(verifier, runner, "sortedInput", sorted(TEST_DATA))
+    compare_dataset(verifier, runner, "descending", sorted(TEST_DATA, reverse=True))
+    compare_dataset(verifier, runner, "constant", [7.0] * 10)
+    compare_dataset(verifier, runner, "negatives", [-10.0, -5.0, 0.0, 5.0, 10.0, 20.0, 30.0])
+    compare_dataset(verifier, runner, "singleValue", [42.5])
+    compare_dataset(verifier, runner, "ema", TEST_DATA, "-e", "5", ema_span=5)
+    compare_dataset(verifier, runner, "trimmedMean", TEST_DATA, "-t", "10", trim_mean_pct=10.0)
+    compare_dataset(verifier, runner, "customK", TEST_DATA, "-k", "3.0", iqr_multiplier=3.0)
+
+    verify_custom_percentiles(verifier, runner)
+    verify_masking(verifier, runner)
+    verify_bin_counts(verifier, runner)
+    verify_trim_dataset(verifier, runner)
+    verify_log_transform(verifier, runner)
+    verify_input_sanitation(verifier, runner)
+    verify_formatting(verifier, runner)
+    verify_flag_behavior(verifier, runner)
+
+    return verifier.report()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/verify_stats.sh
+++ b/verify_stats.sh
@@ -3,6 +3,9 @@
 # Uses the same 31-number dataset from stats_test.go
 # Created on MacOS Sequoia 15.7.3
 # COMPATIBILITY: Must work with bash 5.2+ (GitHub Actions requirement)
+#
+# The program is read through its JSON output (-j) and parsed with jq, so this
+# script compares numbers against numbers rather than scraping padded text.
 
 set -e
 
@@ -10,18 +13,46 @@ set -e
 DATA="5 10 15.5 20 25 30 35 40 45 50 55 60 65 70 75.25 80 85 90 95 100 12.5 37.5 62.5 87.5 50 50 50 3 150 7.75 42"
 COUNT=31
 
-# run_stats runs the built binary if present, otherwise falls back to go run
-run_stats() {
-    if [[ -f "./stats" ]]; then
-        ./stats "$@"
-    else
-        go run stats.go "$@"
+for tool in bc jq; do
+    if ! command -v "$tool" &> /dev/null; then
+        echo "Error: required tool '$tool' not found on PATH"
+        exit 1
+    fi
+done
+
+TMPFILES=()
+cleanup() {
+    if [[ ${#TMPFILES[@]} -gt 0 ]]; then
+        rm -f "${TMPFILES[@]}"
     fi
 }
+trap cleanup EXIT
+
+# new_tempfile writes the given whitespace-separated values one per line and
+# echoes the path. All temp files are removed by the EXIT trap.
+new_tempfile() {
+    local path
+    path=$(mktemp)
+    TMPFILES+=("$path")
+    echo "$1" | tr ' ' '\n' > "$path"
+    echo "$path"
+}
+
+# run_stats runs the built binary if present, otherwise falls back to go run
+run_stats() {
+    if [[ -x "./stats" ]]; then
+        ./stats "$@"
+    else
+        go run . "$@"
+    fi
+}
+
+FAILURES=0
 
 echo "=============================================="
 echo "Independent Verification of Stats Calculator"
 echo "Using bc (arbitrary precision calculator)"
+echo "Program output is read as JSON via jq"
 echo "=============================================="
 echo ""
 echo "Dataset ($COUNT numbers):"
@@ -50,12 +81,6 @@ SORTED_ARRAY=($(echo "$DATA" | tr ' ' '\n' | sort -n))
 
 # Calculate variance and standard deviation
 echo "--- Variance & Standard Deviation ---"
-VARIANCE_CALC=$(cat << EOF | bc -l
-scale=10
-mean = $MEAN
-ssq = 0
-EOF
-)
 
 # Build the sum of squared deviations
 SSQ_EXPR="scale=10; "
@@ -80,6 +105,11 @@ printf "%-20s %.10f%%\n" "CV:" "$CV"
 STDERR=$(echo "scale=10; $STDDEV / sqrt($COUNT)" | bc -l)
 printf "%-20s %.10f\n" "Std Error:" "$STDERR"
 
+# 95% confidence interval for the mean (normal approximation)
+CI_LOWER=$(echo "scale=10; $MEAN - 1.96 * $STDERR" | bc -l)
+CI_UPPER=$(echo "scale=10; $MEAN + 1.96 * $STDERR" | bc -l)
+printf "%-20s [%.10f, %.10f]\n" "95% CI (mean):" "$CI_LOWER" "$CI_UPPER"
+
 # Percentile calculations
 # Formula: rank = p * (n-1), then linear interpolation
 echo ""
@@ -89,8 +119,9 @@ echo ""
 
 calculate_percentile() {
     local p=$1
-    local rank=$(echo "scale=10; $p * ($COUNT - 1)" | bc -l)
-    local lower_idx=$(echo "$rank" | cut -d'.' -f1)
+    local rank
+    rank=$(echo "scale=10; $p * ($COUNT - 1)" | bc -l)
+    local lower_idx=${rank%%.*}
     # Handle case where rank is a whole number
     if [[ "$lower_idx" == "" ]]; then
         lower_idx=0
@@ -99,18 +130,19 @@ calculate_percentile() {
     if [[ $upper_idx -ge $COUNT ]]; then
         upper_idx=$((COUNT - 1))
     fi
-    local weight=$(echo "scale=10; $rank - $lower_idx" | bc -l)
+    local weight
+    weight=$(echo "scale=10; $rank - $lower_idx" | bc -l)
     local lower_val=${SORTED_ARRAY[$lower_idx]}
     local upper_val=${SORTED_ARRAY[$upper_idx]}
-    local result=$(echo "scale=10; $lower_val * (1 - $weight) + $upper_val * $weight" | bc -l)
-    echo "$result"
+    echo "scale=10; $lower_val * (1 - $weight) + $upper_val * $weight" | bc -l
 }
 
 print_percentile_calc() {
     local p=$1
     local name=$2
-    local rank=$(echo "scale=4; $p * ($COUNT - 1)" | bc -l)
-    local lower_idx=$(echo "$rank" | cut -d'.' -f1)
+    local rank
+    rank=$(echo "scale=4; $p * ($COUNT - 1)" | bc -l)
+    local lower_idx=${rank%%.*}
     if [[ "$lower_idx" == "" ]]; then
         lower_idx=0
     fi
@@ -118,23 +150,29 @@ print_percentile_calc() {
     if [[ $upper_idx -ge $COUNT ]]; then
         upper_idx=$((COUNT - 1))
     fi
-    local weight=$(echo "scale=2; $rank - $lower_idx" | bc -l)
+    local weight
+    weight=$(echo "scale=2; $rank - $lower_idx" | bc -l)
     local lower_val=${SORTED_ARRAY[$lower_idx]}
     local upper_val=${SORTED_ARRAY[$upper_idx]}
-    local result=$(echo "scale=4; $lower_val * (1 - $weight) + $upper_val * $weight" | bc -l)
+    local result
+    result=$(echo "scale=4; $lower_val * (1 - $weight) + $upper_val * $weight" | bc -l)
     printf "%-8s rank=%-5s idx[%2d]=%-6s idx[%2d]=%-6s weight=%-4s -> %s\n" \
         "$name" "$rank" "$lower_idx" "$lower_val" "$upper_idx" "$upper_val" "$weight" "$result"
 }
 
+print_percentile_calc 0.10 "P10"
 print_percentile_calc 0.25 "Q1"
 print_percentile_calc 0.50 "Median"
 print_percentile_calc 0.75 "Q3"
+print_percentile_calc 0.90 "P90"
 print_percentile_calc 0.95 "P95"
 print_percentile_calc 0.99 "P99"
 
+P10=$(calculate_percentile 0.10)
 Q1=$(calculate_percentile 0.25)
 MEDIAN=$(calculate_percentile 0.50)
 Q3=$(calculate_percentile 0.75)
+P90=$(calculate_percentile 0.90)
 P95=$(calculate_percentile 0.95)
 P99=$(calculate_percentile 0.99)
 
@@ -218,14 +256,12 @@ printf "%-20s %.10f\n" "Autocorrelation:" "$AUTOCORR"
 echo ""
 echo "--- Z-Score Outliers (threshold=2.0) ---"
 Z_THRESHOLD="2.0"
-Z_OUTLIERS=""
 Z_OUTLIER_COUNT=0
 for val in $DATA; do
     Z=$(echo "scale=10; x=($val - $MEAN) / $STDDEV; if (x < 0) -x else x" | bc -l)
     IS_OUTLIER=$(echo "$Z > $Z_THRESHOLD" | bc -l)
     if [[ "$IS_OUTLIER" == "1" ]]; then
         printf "  %s has Z=%.4f > %s (OUTLIER)\n" "$val" "$Z" "$Z_THRESHOLD"
-        Z_OUTLIERS="$Z_OUTLIERS $val"
         Z_OUTLIER_COUNT=$((Z_OUTLIER_COUNT + 1))
     fi
 done
@@ -251,6 +287,41 @@ if [[ $MODZ_OUTLIER_COUNT -eq 0 ]]; then
 fi
 printf "%-20s %d\n" "Mod Z-Outlier Count:" "$MODZ_OUTLIER_COUNT"
 
+# IQR outliers at k=1.5 and k=3.0
+echo ""
+echo "--- IQR Outliers ---"
+count_iqr_outliers() {
+    local k=$1
+    local lower upper n=0
+    lower=$(echo "scale=10; $Q1 - $k * $IQR" | bc -l)
+    upper=$(echo "scale=10; $Q3 + $k * $IQR" | bc -l)
+    for val in $DATA; do
+        if [[ "$(echo "$val < $lower || $val > $upper" | bc -l)" == "1" ]]; then
+            n=$((n + 1))
+        fi
+    done
+    echo "$n"
+}
+IQR_OUT_K15=$(count_iqr_outliers 1.5)
+IQR_OUT_K30=$(count_iqr_outliers 3.0)
+printf "%-20s %d\n" "Outliers (k=1.5):" "$IQR_OUT_K15"
+printf "%-20s %d\n" "Outliers (k=3.0):" "$IQR_OUT_K30"
+
+# EMA with span 5: alpha = 2/(5+1)
+echo ""
+echo "--- EMA (span 5) ---"
+EMA_SPAN=5
+EMA_ALPHA=$(echo "scale=10; 2 / ($EMA_SPAN + 1)" | bc -l)
+EMA=""
+for val in $DATA; do
+    if [[ -z "$EMA" ]]; then
+        EMA=$val
+    else
+        EMA=$(echo "scale=10; $EMA_ALPHA * $val + (1 - $EMA_ALPHA) * $EMA" | bc -l)
+    fi
+done
+printf "%-20s %.10f\n" "EMA (span 5):" "$EMA"
+
 # Now run the actual program and compare
 echo ""
 echo "=============================================="
@@ -258,76 +329,51 @@ echo "Running stats program on same dataset..."
 echo "=============================================="
 echo ""
 
-# Create temp file with dataset
-TMPFILE=$(mktemp)
-echo "$DATA" | tr ' ' '\n' > "$TMPFILE"
+TMPFILE=$(new_tempfile "$DATA")
+JSON=$(run_stats -j -z 2.0 -p "10,90" "$TMPFILE")
 
-# Run stats program (assuming it's built or we use go run)
-if [[ -f "./stats" ]]; then
-    PROGRAM_OUTPUT=$(./stats -z 2.0 "$TMPFILE")
-elif command -v go &> /dev/null; then
-    PROGRAM_OUTPUT=$(go run stats.go -z 2.0 "$TMPFILE")
-else
-    echo "Error: Neither ./stats binary nor go command found"
-    rm "$TMPFILE"
-    exit 1
-fi
-
-rm "$TMPFILE"
-
-echo "$PROGRAM_OUTPUT"
-echo ""
-
-# Extract values from program output for comparison
-extract_value() {
-    echo "$PROGRAM_OUTPUT" | grep -E "^$1" | awk '{print $NF}' | tr -d '()'
+# jq always exits 0 for a missing key (it yields null), so no comparison below
+# can abort the script before its result is reported.
+jget() {
+    echo "$JSON" | jq -r "$1"
 }
 
-PROG_SUM=$(extract_value "Sum:")
-PROG_MEAN=$(extract_value "Mean:")
-PROG_MEDIAN=$(extract_value "Median")
-PROG_STDDEV=$(extract_value "Std Deviation:")
-PROG_VARIANCE=$(extract_value "Variance:")
-PROG_Q1=$(extract_value "Quartile 1")
-PROG_Q3=$(extract_value "Quartile 3")
-PROG_P95=$(echo "$PROGRAM_OUTPUT" | grep "p95" | awk '{print $NF}')
-PROG_P99=$(echo "$PROGRAM_OUTPUT" | grep "p99" | awk '{print $NF}')
-PROG_IQR=$(extract_value "IQR:")
-PROG_CV=$(echo "$PROGRAM_OUTPUT" | grep "^CV:" | awk '{print $2}' | tr -d '%')
-PROG_SKEWNESS=$(echo "$PROGRAM_OUTPUT" | grep "^Skewness:" | awk '{print $2}')
-PROG_KURTOSIS=$(echo "$PROGRAM_OUTPUT" | grep "^Kurtosis:" | awk '{print $2}')
-PROG_MIN=$(extract_value "Min:")
-PROG_MAX=$(extract_value "Max:")
-PROG_STDERR=$(extract_value "Std Error:")
-PROG_GEOMEAN=$(extract_value "Geometric Mean:")
-PROG_MAD=$(extract_value "MAD:")
-PROG_DISTINCT=$(echo "$PROGRAM_OUTPUT" | grep "^Distinct:" | awk '{print $2}')
-PROG_DUP_PCT=$(echo "$PROGRAM_OUTPUT" | grep "^Distinct:" | awk '{print $5}' | tr -d '(%')
-PROG_AUTOCORR=$(echo "$PROGRAM_OUTPUT" | grep "^Autocorrelation:" | awk '{print $2}')
+run_stats -z 2.0 "$TMPFILE"
+echo ""
 
-# Comparison function (using bc for float comparison)
-FAILURES=0
-
+# Comparison helpers
 compare_values() {
     local name=$1
     local bc_val=$2
     local prog_val=$3
     local tolerance=0.0001
 
-    # Handle empty values
-    if [[ -z "$prog_val" ]]; then
-        printf "| %-12s | %15s | %15s | %-6s |\n" "$name" "$bc_val" "N/A" "SKIP"
+    if [[ -z "$prog_val" || "$prog_val" == "null" ]]; then
+        printf "| %-14s | %15s | %15s | %-6s |\n" "$name" "$bc_val" "MISSING" "x"
         FAILURES=$((FAILURES + 1))
         return
     fi
 
-    local diff=$(echo "scale=10; x=$bc_val - $prog_val; if (x < 0) -x else x" | bc -l)
-    local match=$(echo "$diff < $tolerance" | bc -l)
+    local diff match
+    diff=$(echo "scale=10; x=$bc_val - $prog_val; if (x < 0) -x else x" | bc -l)
+    match=$(echo "$diff < $tolerance" | bc -l)
 
     if [[ "$match" == "1" ]]; then
-        printf "| %-12s | %15.4f | %15s | %-6s |\n" "$name" "$bc_val" "$prog_val" "✓"
+        printf "| %-14s | %15.4f | %15.4f | %-6s |\n" "$name" "$bc_val" "$prog_val" "ok"
     else
-        printf "| %-12s | %15.4f | %15s | %-6s |\n" "$name" "$bc_val" "$prog_val" "✗"
+        printf "| %-14s | %15.4f | %15.4f | %-6s |\n" "$name" "$bc_val" "$prog_val" "x"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+check() {
+    local description=$1
+    local actual=$2
+    local expected=$3
+    if [[ "$actual" == "$expected" ]]; then
+        echo "PASS: $description"
+    else
+        echo "FAIL: $description (got '$actual', expected '$expected')"
         FAILURES=$((FAILURES + 1))
     fi
 }
@@ -336,93 +382,94 @@ echo "=============================================="
 echo "Verification Summary"
 echo "=============================================="
 echo ""
-printf "| %-12s | %15s | %15s | %-6s |\n" "Statistic" "bc Calculation" "Program Output" "Match"
-printf "|--------------|-----------------|-----------------|--------|\n"
-compare_values "Sum" "$SUM" "$PROG_SUM"
-compare_values "Mean" "$MEAN" "$PROG_MEAN"
-compare_values "Variance" "$VARIANCE" "$PROG_VARIANCE"
-compare_values "StdDev" "$STDDEV" "$PROG_STDDEV"
-compare_values "Min" "$MIN" "$PROG_MIN"
-compare_values "Max" "$MAX" "$PROG_MAX"
-compare_values "Q1 (p25)" "$Q1" "$PROG_Q1"
-compare_values "Median (p50)" "$MEDIAN" "$PROG_MEDIAN"
-compare_values "Q3 (p75)" "$Q3" "$PROG_Q3"
-compare_values "P95" "$P95" "$PROG_P95"
-compare_values "P99" "$P99" "$PROG_P99"
-compare_values "IQR" "$IQR" "$PROG_IQR"
-compare_values "CV (%)" "$CV" "$PROG_CV"
-compare_values "StdErr" "$STDERR" "$PROG_STDERR"
-compare_values "GeoMean" "$GEOMEAN" "$PROG_GEOMEAN"
-compare_values "MAD" "$MAD_SCALED" "$PROG_MAD"
-compare_values "Distinct" "$DISTINCT" "$PROG_DISTINCT"
-compare_values "Dup Pct (%)" "$DUP_PCT" "$PROG_DUP_PCT"
-compare_values "Autocorr" "$AUTOCORR" "$PROG_AUTOCORR"
-compare_values "Skewness" "$SKEWNESS" "$PROG_SKEWNESS"
-compare_values "Kurtosis" "$KURTOSIS" "$PROG_KURTOSIS"
+printf "| %-14s | %15s | %15s | %-6s |\n" "Statistic" "bc Calculation" "Program Output" "Match"
+printf "|----------------|-----------------|-----------------|--------|\n"
+compare_values "Count"          "$COUNT"       "$(jget .count)"
+compare_values "Sum"            "$SUM"         "$(jget .sum)"
+compare_values "Mean"           "$MEAN"        "$(jget .mean)"
+compare_values "Variance"       "$VARIANCE"    "$(jget .variance)"
+compare_values "StdDev"         "$STDDEV"      "$(jget .stdDev)"
+compare_values "Min"            "$MIN"         "$(jget .min)"
+compare_values "Max"            "$MAX"         "$(jget .max)"
+compare_values "Q1 (p25)"       "$Q1"          "$(jget .q1)"
+compare_values "Median (p50)"   "$MEDIAN"      "$(jget .median)"
+compare_values "Q3 (p75)"       "$Q3"          "$(jget .q3)"
+compare_values "P95"            "$P95"         "$(jget .p95)"
+compare_values "P99"            "$P99"         "$(jget .p99)"
+compare_values "IQR"            "$IQR"         "$(jget .iqr)"
+compare_values "CV (%)"         "$CV"          "$(jget .cv)"
+compare_values "StdErr"         "$STDERR"      "$(jget .stdErr)"
+compare_values "CI95 Lower"     "$CI_LOWER"    "$(jget .ci95Lower)"
+compare_values "CI95 Upper"     "$CI_UPPER"    "$(jget .ci95Upper)"
+compare_values "GeoMean"        "$GEOMEAN"     "$(jget .geometricMean)"
+compare_values "MAD"            "$MAD_SCALED"  "$(jget .mad)"
+compare_values "Distinct"       "$DISTINCT"    "$(jget .distinct)"
+compare_values "Dup Pct (%)"    "$DUP_PCT"     "$(jget .duplicatePct)"
+compare_values "Autocorr"       "$AUTOCORR"    "$(jget .autocorrelation)"
+compare_values "Skewness"       "$SKEWNESS"    "$(jget .skewness)"
+compare_values "Kurtosis"       "$KURTOSIS"    "$(jget .kurtosis)"
+compare_values "Z-Outliers"     "$Z_OUTLIER_COUNT"    "$(jget '.zScoreOutliers | length')"
+compare_values "Mod Z-Out"      "$MODZ_OUTLIER_COUNT" "$(jget '.modZOutliers | length')"
+compare_values "IQR Outliers"   "$IQR_OUT_K15"        "$(jget '.outliers | length')"
+compare_values "Custom p10"     "$P10"         "$(jget '.customPercentiles["10"]')"
+compare_values "Custom p90"     "$P90"         "$(jget '.customPercentiles["90"]')"
+echo ""
 
-# Extract Z-score outlier count from program output
-PROG_Z_LINE=$(echo "$PROGRAM_OUTPUT" | grep "^Z-Outliers")
-if [[ -n "$PROG_Z_LINE" ]]; then
-    # Count values in brackets: extract bracket content, count space-separated items
-    PROG_Z_CONTENT=$(echo "$PROG_Z_LINE" | sed 's/.*\[//' | sed 's/\].*//')
-    if [[ "$PROG_Z_CONTENT" == *"None"* ]] || [[ -z "$PROG_Z_CONTENT" ]]; then
-        PROG_Z_COUNT=0
-    else
-        PROG_Z_COUNT=$(echo "$PROG_Z_CONTENT" | wc -w | tr -d ' ')
-    fi
-    compare_values "Z-Outliers" "$Z_OUTLIER_COUNT" "$PROG_Z_COUNT"
-else
-    printf "| %-12s | %15s | %15s | %-6s |\n" "Z-Outliers" "$Z_OUTLIER_COUNT" "N/A" "SKIP"
-    FAILURES=$((FAILURES + 1))
-fi
+# --- Structural checks on the JSON payload ---
+echo "--- Structural Checks ---"
+check "isSymmetric is false for the asymmetric dataset" "$(jget .isSymmetric)" "false"
+check "inputOrder reports unordered"                    "$(jget .inputOrder)" "unordered"
+check "skippedLines is 0 for clean input"               "$(jget .skippedLines)" "0"
+check "zScoreValid is true"                             "$(jget .zScoreValid)" "true"
+check "modZValid is true"                               "$(jget .modZValid)" "true"
+check "modalBinValid is false when a mode exists"       "$(jget .modalBinValid)" "false"
+check "mode is [50]"                                    "$(jget '.mode | join(",")')" "50"
+check "histogram has 16 bins"                           "$(jget '.histogram | length')" "16"
+check "trendline has 16 bins"                           "$(jget '.trendline | length')" "16"
+check "version matches the binary"                      "$(jget .version)" "$(run_stats -v | head -1 | awk '{print $NF}')"
+echo ""
 
-# Extract modified z-score outlier count from program output
-PROG_MODZ_LINE=$(echo "$PROGRAM_OUTPUT" | grep "^Mod Z-Outliers" || true)
-if [[ -n "$PROG_MODZ_LINE" ]]; then
-    PROG_MODZ_CONTENT=$(echo "$PROG_MODZ_LINE" | sed 's/.*\[//' | sed 's/\].*//')
-    if [[ "$PROG_MODZ_CONTENT" == *"None"* ]] || [[ -z "$PROG_MODZ_CONTENT" ]]; then
-        PROG_MODZ_COUNT=0
-    else
-        PROG_MODZ_COUNT=$(echo "$PROG_MODZ_CONTENT" | wc -w | tr -d ' ')
-    fi
-    compare_values "Mod Z-Out" "$MODZ_OUTLIER_COUNT" "$PROG_MODZ_COUNT"
+# --- Outlier sensitivity (-k) ---
+echo "=============================================="
+echo "Outlier Sensitivity Verification (-k)"
+echo "=============================================="
+echo ""
+K30_JSON=$(run_stats -j -k 3.0 "$TMPFILE")
+check "k=3.0 flags $IQR_OUT_K30 outlier(s)" "$(echo "$K30_JSON" | jq -r '.outliers | length')" "$IQR_OUT_K30"
+check "k=3.0 is recorded in the output"     "$(echo "$K30_JSON" | jq -r '.iqrMultiplier')" "3"
+
+set +e
+K_BAD_OUTPUT=$(run_stats -k 0 "$TMPFILE" 2>&1)
+K_BAD_STATUS=$?
+set -e
+if [[ $K_BAD_STATUS -ne 0 ]] && [[ "$K_BAD_OUTPUT" == *"greater than 0"* ]]; then
+    echo "PASS: -k 0 is rejected"
 else
-    printf "| %-12s | %15s | %15s | %-6s |\n" "Mod Z-Out" "$MODZ_OUTLIER_COUNT" "N/A" "SKIP"
+    echo "FAIL: expected -k 0 to be rejected (exit=$K_BAD_STATUS)"
     FAILURES=$((FAILURES + 1))
 fi
 echo ""
 
-# --- Structural checks on the main output (v1.12.0 / v1.13.0 lines) ---
-echo "--- Structural Checks (main output) ---"
-if echo "$PROGRAM_OUTPUT" | grep -q "^Symmetry:.*None"; then
-    echo "PASS: Symmetry reports None for the asymmetric dataset"
-else
-    echo "FAIL: expected 'Symmetry: None'"
-    FAILURES=$((FAILURES + 1))
-fi
-if echo "$PROGRAM_OUTPUT" | grep -q "^Input Order:.*unordered"; then
-    echo "PASS: Input Order reports unordered"
-else
-    echo "FAIL: expected 'Input Order: unordered'"
-    FAILURES=$((FAILURES + 1))
-fi
-if echo "$PROGRAM_OUTPUT" | grep -q "^Skipped:"; then
-    echo "FAIL: Skipped line should be absent for clean input"
-    FAILURES=$((FAILURES + 1))
-else
-    echo "PASS: no Skipped line for clean input"
-fi
+# --- EMA Verification ---
+echo "=============================================="
+echo "EMA Verification (-e 5)"
+echo "=============================================="
+echo ""
+EMA_JSON=$(run_stats -j -e 5 "$TMPFILE")
+printf "| %-14s | %15s | %15s | %-6s |\n" "Statistic" "bc Calculation" "Program Output" "Match"
+printf "|----------------|-----------------|-----------------|--------|\n"
+compare_values "EMA (span 5)" "$EMA" "$(echo "$EMA_JSON" | jq -r '.ema')"
+check "emaSpan is recorded" "$(echo "$EMA_JSON" | jq -r '.emaSpan')" "5"
 echo ""
 
 # --- Trimmed Mean Verification ---
 echo "=============================================="
-echo "Trimmed Mean Verification (trim=10%)"
+echo "Trimmed Mean Verification (-t 10)"
 echo "=============================================="
 echo ""
 
 # trimCount = floor(31 * 10 / 100) = 3
 # Remove 3 from each end of sorted data, average remaining 25 values
-# Sorted indices 3..27 (0-based)
 TRIM_COUNT=3
 TRIM_REMAINING=$((COUNT - 2 * TRIM_COUNT))
 
@@ -432,45 +479,27 @@ for i in $(seq $TRIM_COUNT $((COUNT - TRIM_COUNT - 1))); do
 done
 TRIM_MEAN=$(echo "scale=10; $TRIM_SUM / $TRIM_REMAINING" | bc -l)
 printf "%-20s %s (from %d values, trimmed %d from each end)\n" "Trimmed Mean:" "$TRIM_MEAN" "$TRIM_REMAINING" "$TRIM_COUNT"
-
-# Run program with -t 10
-TMPFILE3=$(mktemp)
-echo "$DATA" | tr ' ' '\n' > "$TMPFILE3"
-
-if [[ -f "./stats" ]]; then
-    TRIM_OUTPUT=$(./stats -t 10 "$TMPFILE3")
-elif command -v go &> /dev/null; then
-    TRIM_OUTPUT=$(go run stats.go -t 10 "$TMPFILE3")
-else
-    echo "Error: Neither ./stats binary nor go command found"
-    rm "$TMPFILE3"
-    exit 1
-fi
-
-rm "$TMPFILE3"
-
-PROG_TRIM_MEAN=$(echo "$TRIM_OUTPUT" | grep "^Trimmed Mean" | awk '{print $NF}')
-
 echo ""
-printf "| %-12s | %15s | %15s | %-6s |\n" "Statistic" "bc Calculation" "Program Output" "Match"
-printf "|--------------|-----------------|-----------------|--------|\n"
-compare_values "Trim Mean" "$TRIM_MEAN" "$PROG_TRIM_MEAN"
+
+TRIM_JSON=$(run_stats -j -t 10 "$TMPFILE")
+printf "| %-14s | %15s | %15s | %-6s |\n" "Statistic" "bc Calculation" "Program Output" "Match"
+printf "|----------------|-----------------|-----------------|--------|\n"
+compare_values "Trim Mean" "$TRIM_MEAN" "$(echo "$TRIM_JSON" | jq -r '.trimmedMean')"
+compare_values "Full Mean"  "$MEAN"      "$(echo "$TRIM_JSON" | jq -r '.mean')"
 echo ""
 
 # --- Log Transform Verification ---
 echo "=============================================="
-echo "Log Transform Verification"
+echo "Log Transform Verification (-l)"
 echo "=============================================="
 echo ""
 
-# Compute ln of each value and their mean using bc
 LOG_SUM="0"
 for val in $DATA; do
     LOG_SUM=$(echo "scale=10; $LOG_SUM + l($val)" | bc -l)
 done
 LOG_MEAN=$(echo "scale=10; $LOG_SUM / $COUNT" | bc -l)
 
-# Compute ln variance and stddev
 LOG_SSQ="0"
 for val in $DATA; do
     LOG_VAL=$(echo "scale=10; l($val)" | bc -l)
@@ -479,38 +508,17 @@ done
 LOG_VARIANCE=$(echo "scale=10; $LOG_SSQ / ($COUNT - 1)" | bc -l)
 LOG_STDDEV=$(echo "scale=10; sqrt($LOG_VARIANCE)" | bc -l)
 
-# Run program with -l flag
-TMPFILE2=$(mktemp)
-echo "$DATA" | tr ' ' '\n' > "$TMPFILE2"
-
-if [[ -f "./stats" ]]; then
-    LOG_OUTPUT=$(./stats -l "$TMPFILE2")
-elif command -v go &> /dev/null; then
-    LOG_OUTPUT=$(go run stats.go -l "$TMPFILE2")
-else
-    echo "Error: Neither ./stats binary nor go command found"
-    rm "$TMPFILE2"
-    exit 1
-fi
-
-rm "$TMPFILE2"
-
-echo "$LOG_OUTPUT"
+LOG_JSON=$(run_stats -j -l "$TMPFILE")
+printf "| %-14s | %15s | %15s | %-6s |\n" "Statistic" "bc Calculation" "Program Output" "Match"
+printf "|----------------|-----------------|-----------------|--------|\n"
+compare_values "Log Mean"     "$LOG_MEAN"     "$(echo "$LOG_JSON" | jq -r '.mean')"
+compare_values "Log StdDev"   "$LOG_STDDEV"   "$(echo "$LOG_JSON" | jq -r '.stdDev')"
+compare_values "Log Variance" "$LOG_VARIANCE" "$(echo "$LOG_JSON" | jq -r '.variance')"
+check "geoMeanValid is false under -l" "$(echo "$LOG_JSON" | jq -r '.geoMeanValid')" "false"
+check "logTransformed is true"         "$(echo "$LOG_JSON" | jq -r '.logTransformed')" "true"
 echo ""
 
-# Extract values from log-transformed output
-PROG_LOG_MEAN=$(echo "$LOG_OUTPUT" | grep "^Mean:" | awk '{print $2}')
-PROG_LOG_STDDEV=$(echo "$LOG_OUTPUT" | grep "^Std Deviation:" | awk '{print $NF}')
-PROG_LOG_VARIANCE=$(echo "$LOG_OUTPUT" | grep "^Variance:" | awk '{print $NF}')
-
-printf "| %-12s | %15s | %15s | %-6s |\n" "Statistic" "bc Calculation" "Program Output" "Match"
-printf "|--------------|-----------------|-----------------|--------|\n"
-compare_values "Log Mean" "$LOG_MEAN" "$PROG_LOG_MEAN"
-compare_values "Log StdDev" "$LOG_STDDEV" "$PROG_LOG_STDDEV"
-compare_values "Log Variance" "$LOG_VARIANCE" "$PROG_LOG_VARIANCE"
-echo ""
-
-# --- Symmetry Verification (v1.12.0) ---
+# --- Symmetry Verification ---
 echo "=============================================="
 echo "Symmetry Verification"
 echo "=============================================="
@@ -529,7 +537,7 @@ for i in $(seq 0 $((SYM_COUNT / 2 - 1))); do
     PAIR_SUM=$(echo "${SYM_SORTED[$i]} + ${SYM_SORTED[$((SYM_COUNT - 1 - i))]}" | bc -l)
     MATCH=$(echo "$PAIR_SUM == 2 * $SYM_CENTER" | bc -l)
     if [[ "$MATCH" != "1" ]]; then
-        echo "FAIL: pair ${SYM_SORTED[$i]} + ${SYM_SORTED[$((SYM_COUNT - 1 - i))]} = $PAIR_SUM, expected $(echo "2 * $SYM_CENTER" | bc -l)"
+        echo "FAIL: pair ${SYM_SORTED[$i]} + ${SYM_SORTED[$((SYM_COUNT - 1 - i))]} = $PAIR_SUM"
         PAIR_FAILURES=$((PAIR_FAILURES + 1))
     fi
 done
@@ -539,70 +547,101 @@ else
     FAILURES=$((FAILURES + PAIR_FAILURES))
 fi
 
-TMPFILE5=$(mktemp)
-echo "$SYMDATA" | tr ' ' '\n' > "$TMPFILE5"
-SYM_OUTPUT=$(run_stats "$TMPFILE5")
-rm "$TMPFILE5"
-
-if echo "$SYM_OUTPUT" | grep -qF "Symmetric about 500 (20 pairs)"; then
-    echo "PASS: program reports 'Symmetric about 500 (20 pairs)'"
-else
-    echo "FAIL: program did not report the expected symmetry line"
-    FAILURES=$((FAILURES + 1))
-fi
+SYMFILE=$(new_tempfile "$SYMDATA")
+SYM_JSON=$(run_stats -j "$SYMFILE")
+check "isSymmetric is true"      "$(echo "$SYM_JSON" | jq -r '.isSymmetric')"    "true"
+check "symmetryCenter is 500"    "$(echo "$SYM_JSON" | jq -r '.symmetryCenter')" "500"
+check "symmetryPairs is 20"      "$(echo "$SYM_JSON" | jq -r '.symmetryPairs')"  "20"
+# All 40 values are distinct, so the mode falls back to the densest histogram bin
+check "mode is empty"            "$(echo "$SYM_JSON" | jq -r '.mode | length')"  "0"
+check "modalBinValid is true"    "$(echo "$SYM_JSON" | jq -r '.modalBinValid')"  "true"
 echo ""
 
-# --- Skipped Lines Verification (v1.13.0) ---
+# --- Skipped Lines Verification ---
 echo "=============================================="
 echo "Skipped Lines Verification"
 echo "=============================================="
 echo ""
 
-# 2 invalid lines (abc, xyz); the 2 blank lines must not be counted
-TMPFILE6=$(mktemp)
-printf '10\n\nabc\n20\n\nxyz\n30\n' > "$TMPFILE6"
-SKIP_OUTPUT=$(run_stats "$TMPFILE6" 2>/dev/null)
-rm "$TMPFILE6"
-
-SKIP_COUNT=$(echo "$SKIP_OUTPUT" | grep "^Skipped:" | awk '{print $2}' || true)
-if [[ "$SKIP_COUNT" == "2" ]]; then
-    echo "PASS: Skipped reports 2 invalid lines (blank lines not counted)"
-else
-    echo "FAIL: Skipped count is '$SKIP_COUNT', expected 2"
-    FAILURES=$((FAILURES + 1))
-fi
-SKIP_DATA_COUNT=$(echo "$SKIP_OUTPUT" | grep "^Count:" | awk '{print $2}' || true)
-if [[ "$SKIP_DATA_COUNT" == "3" ]]; then
-    echo "PASS: Count is 3 valid values"
-else
-    echo "FAIL: Count is '$SKIP_DATA_COUNT', expected 3"
-    FAILURES=$((FAILURES + 1))
-fi
+# 2 unparseable lines (abc, xyz) plus 2 non-finite values that parse but must be
+# rejected (NaN, Inf); the 2 blank lines must not be counted
+SKIPFILE=$(mktemp)
+TMPFILES+=("$SKIPFILE")
+printf '10\n\nabc\n20\n\nxyz\n30\nNaN\nInf\n' > "$SKIPFILE"
+SKIP_JSON=$(run_stats -j "$SKIPFILE" 2>/dev/null)
+check "skippedLines is 4 (blank lines excluded)" "$(echo "$SKIP_JSON" | jq -r '.skippedLines')" "4"
+check "count is 3 valid values"                  "$(echo "$SKIP_JSON" | jq -r '.count')" "3"
+check "sum is unaffected by NaN"                 "$(echo "$SKIP_JSON" | jq -r '.sum')" "60"
+check "max is unaffected by Inf"                 "$(echo "$SKIP_JSON" | jq -r '.max')" "30"
 echo ""
 
-# --- Input Order Verification (v1.13.0) ---
+# --- Input Order Verification ---
 echo "=============================================="
 echo "Input Order Verification (sorted input)"
 echo "=============================================="
 echo ""
 
-TMPFILE7=$(mktemp)
-echo "$DATA" | tr ' ' '\n' | sort -n > "$TMPFILE7"
-ORDER_OUTPUT=$(run_stats "$TMPFILE7")
-rm "$TMPFILE7"
+SORTFILE=$(new_tempfile "$SORTED")
+check "sorted input reports ascending" "$(run_stats -j "$SORTFILE" | jq -r '.inputOrder')" "ascending"
 
-ORDER_LINE=$(echo "$ORDER_OUTPUT" | grep "^Input Order:" || true)
-if echo "$ORDER_LINE" | grep -q "ascending"; then
-    echo "PASS: sorted input reports ascending"
-else
-    echo "FAIL: sorted input did not report ascending: $ORDER_LINE"
-    FAILURES=$((FAILURES + 1))
-fi
-if echo "$ORDER_LINE" | grep -q "WARNING"; then
+ORDER_TEXT=$(run_stats "$SORTFILE")
+if [[ "$ORDER_TEXT" == *"WARNING: trendline and autocorrelation reflect this sort order"* ]]; then
     echo "PASS: sorted input carries the sort-order warning"
 else
     echo "FAIL: sorted input is missing the sort-order warning"
     FAILURES=$((FAILURES + 1))
+fi
+ORDER_EMA_TEXT=$(run_stats -e 5 "$SORTFILE")
+if [[ "$ORDER_EMA_TEXT" == *"WARNING: trendline, autocorrelation, and EMA reflect this sort order"* ]]; then
+    echo "PASS: sort-order warning names EMA when -e is active"
+else
+    echo "FAIL: sort-order warning does not name EMA under -e"
+    FAILURES=$((FAILURES + 1))
+fi
+echo ""
+
+# --- Degenerate Z-Score Verification ---
+echo "=============================================="
+echo "Degenerate Z-Score Verification (zero spread)"
+echo "=============================================="
+echo ""
+
+FLATFILE=$(new_tempfile "5 5 5 5")
+FLAT_JSON=$(run_stats -j -z 2.0 "$FLATFILE")
+check "zScoreThreshold is still recorded" "$(echo "$FLAT_JSON" | jq -r '.zScoreThreshold')" "2"
+check "zScoreValid is false"              "$(echo "$FLAT_JSON" | jq -r '.zScoreValid')" "false"
+check "modZValid is false"                "$(echo "$FLAT_JSON" | jq -r '.modZValid')" "false"
+
+FLAT_TEXT=$(run_stats -z 2.0 "$FLATFILE")
+if [[ "$FLAT_TEXT" == *"N/A - standard deviation is zero"* ]]; then
+    echo "PASS: Z-outlier line reports N/A rather than vanishing"
+else
+    echo "FAIL: Z-outlier line is missing for zero-spread data"
+    FAILURES=$((FAILURES + 1))
+fi
+echo ""
+
+# --- Small Magnitude Formatting Verification ---
+echo "=============================================="
+echo "Small Magnitude Formatting Verification"
+echo "=============================================="
+echo ""
+
+TINYFILE=$(new_tempfile "0.00004 0.00006")
+TINY_TEXT=$(run_stats "$TINYFILE")
+for expected in "0.00004" "0.00006" "0.00005"; do
+    if [[ "$TINY_TEXT" == *"$expected"* ]]; then
+        echo "PASS: $expected survives formatting"
+    else
+        echo "FAIL: $expected was lost in formatting"
+        FAILURES=$((FAILURES + 1))
+    fi
+done
+if [[ "$TINY_TEXT" == *"e-0"* ]] || [[ "$TINY_TEXT" == *"E-0"* ]]; then
+    echo "FAIL: output used scientific notation"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "PASS: output avoids scientific notation"
 fi
 echo ""
 
@@ -612,99 +651,66 @@ echo "Trim Dataset Verification (-T 10)"
 echo "=============================================="
 echo ""
 
-TMPFILE4=$(mktemp)
-echo "$DATA" | tr ' ' '\n' > "$TMPFILE4"
+TRIMD_JSON=$(run_stats -j -T 10 "$TMPFILE")
+check "count is 25 (trimmed from 31)"  "$(echo "$TRIMD_JSON" | jq -r '.count')" "25"
+check "trimDatasetOrigN is 31"         "$(echo "$TRIMD_JSON" | jq -r '.trimDatasetOrigN')" "31"
+check "trimDatasetPct is 10"           "$(echo "$TRIMD_JSON" | jq -r '.trimDatasetPct')" "10"
+check "trendline is suppressed"        "$(echo "$TRIMD_JSON" | jq -r '.trendline')" ""
+check "autocorrValid is false"         "$(echo "$TRIMD_JSON" | jq -r '.autocorrValid')" "false"
+check "inputOrder is suppressed"       "$(echo "$TRIMD_JSON" | jq -r '.inputOrder')" ""
+compare_values "Trimmed Mean" "$TRIM_MEAN" "$(echo "$TRIMD_JSON" | jq -r '.mean')"
 
-if [[ -f "./stats" ]]; then
-    TRIMD_OUTPUT=$(./stats -T 10 "$TMPFILE4")
-elif command -v go &> /dev/null; then
-    TRIMD_OUTPUT=$(go run stats.go -T 10 "$TMPFILE4")
+TRIMD_TEXT=$(run_stats -T 10 "$TMPFILE")
+if [[ "$TRIMD_TEXT" == *"(trimmed dataset: 10% from each tail, 31 → 25 values)"* ]]; then
+    echo "PASS: trimmed-dataset header present"
 else
-    echo "Error: Neither ./stats binary nor go command found"
-    rm "$TMPFILE4"
-    exit 1
+    echo "FAIL: trimmed-dataset header missing or malformed"
+    FAILURES=$((FAILURES + 1))
 fi
-
-rm "$TMPFILE4"
-
-echo "$TRIMD_OUTPUT"
+if [[ "$TRIMD_TEXT" == *"all statistics above are computed on the trimmed dataset"* ]]; then
+    echo "PASS: trimmed-dataset footnote present"
+else
+    echo "FAIL: trimmed-dataset footnote missing"
+    FAILURES=$((FAILURES + 1))
+fi
+# The star convention was dropped: no label may end in '*'
+if echo "$TRIMD_TEXT" | grep -qE '^[A-Za-z0-9 ()%>.]+\*:'; then
+    echo "FAIL: found a starred label; the star convention was removed"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "PASS: no starred labels under -T"
+fi
 echo ""
 
-# Verify header line present with correct counts
-TRIMD_HEADER=$(echo "$TRIMD_OUTPUT" | grep "^(trimmed dataset:")
-if [[ -z "$TRIMD_HEADER" ]]; then
-    echo "FAIL: Trim dataset header not found"
-    FAILURES=$((FAILURES + 1))
-else
-    echo "PASS: Trim dataset header present: $TRIMD_HEADER"
-    # Verify counts in header (31 → 25)
-    if echo "$TRIMD_HEADER" | grep -q "31 → 25"; then
-        echo "PASS: Header shows correct counts (31 → 25)"
+# --- Mutual Exclusion Verification ---
+echo "=============================================="
+echo "Mutual Exclusion Verification"
+echo "=============================================="
+echo ""
+
+check_rejected() {
+    local description=$1
+    shift
+    local output status
+    set +e
+    output=$(run_stats "$@" 2>&1)
+    status=$?
+    set -e
+    if [[ $status -ne 0 ]] && [[ "$output" == *"$EXPECT_SUBSTR"* ]]; then
+        echo "PASS: $description"
     else
-        echo "FAIL: Header does not show expected counts (31 → 25)"
+        echo "FAIL: $description (exit=$status)"
         FAILURES=$((FAILURES + 1))
     fi
-fi
+}
 
-# Verify Count shows 25
-TRIMD_COUNT=$(echo "$TRIMD_OUTPUT" | grep "^Count:" | awk '{print $2}')
-if [[ "$TRIMD_COUNT" == "25" ]]; then
-    echo "PASS: Count is 25 (trimmed from 31)"
-else
-    echo "FAIL: Count is $TRIMD_COUNT, expected 25"
-    FAILURES=$((FAILURES + 1))
-fi
+EXPECT_SUBSTR="mutually exclusive"
+check_rejected "-t and -T are mutually exclusive" -t 10 -T 10 "$TMPFILE"
+check_rejected "-e and -T are mutually exclusive" -e 5 -T 10 "$TMPFILE"
 
-# Verify Trendline absent
-TRIMD_TRENDLINE=$(echo "$TRIMD_OUTPUT" | grep "^Trendline:" || true)
-if [[ -z "$TRIMD_TRENDLINE" ]]; then
-    echo "PASS: Trendline absent (as expected for trimmed dataset)"
-else
-    echo "FAIL: Trendline should be absent for trimmed dataset"
-    FAILURES=$((FAILURES + 1))
-fi
-
-# Verify footnote present
-TRIMD_FOOTNOTE=$(echo "$TRIMD_OUTPUT" | grep "computed on trimmed dataset")
-if [[ -n "$TRIMD_FOOTNOTE" ]]; then
-    echo "PASS: Footnote present"
-else
-    echo "FAIL: Footnote not found"
-    FAILURES=$((FAILURES + 1))
-fi
-
-# Verify MAD carries the trimmed-dataset star (v1.13.0)
-if echo "$TRIMD_OUTPUT" | grep -q "^MAD\*:"; then
-    echo "PASS: MAD is starred under -T"
-else
-    echo "FAIL: MAD should carry * under -T"
-    FAILURES=$((FAILURES + 1))
-fi
-
-# Verify order-aware statistics are suppressed, like the Trendline (v1.13.0)
-for LABEL in "Autocorrelation:" "Input Order:"; do
-    if echo "$TRIMD_OUTPUT" | grep -q "^$LABEL"; then
-        echo "FAIL: $LABEL should be absent under -T"
-        FAILURES=$((FAILURES + 1))
-    else
-        echo "PASS: $LABEL absent under -T"
-    fi
-done
-
-# Verify -e and -T are mutually exclusive (v1.13.0)
-TMPFILE8=$(mktemp)
-echo "$DATA" | tr ' ' '\n' > "$TMPFILE8"
-set +e
-EXCL_OUTPUT=$(run_stats -e 5 -T 10 "$TMPFILE8" 2>&1)
-EXCL_STATUS=$?
-set -e
-rm "$TMPFILE8"
-if [[ $EXCL_STATUS -ne 0 ]] && echo "$EXCL_OUTPUT" | grep -q "mutually exclusive"; then
-    echo "PASS: -e and -T are mutually exclusive"
-else
-    echo "FAIL: expected -e/-T mutual exclusion error (exit=$EXCL_STATUS)"
-    FAILURES=$((FAILURES + 1))
-fi
+EXPECT_SUBSTR="expected at most one input file"
+check_rejected "options after the filename are rejected" "$TMPFILE" -z 2.0
+check_rejected "two input files are rejected" "$TMPFILE" "$TMPFILE"
 
 echo ""
 
@@ -712,6 +718,6 @@ if [[ $FAILURES -eq 0 ]]; then
     echo "Verification complete. All values match."
     exit 0
 else
-    echo "Verification FAILED. $FAILURES value(s) did not match."
+    echo "Verification FAILED. $FAILURES check(s) did not match."
     exit 1
 fi


### PR DESCRIPTION
## Summary

A bug hunt over the calculations, tests, verification script, and README. The headline result is reassuring: **the statistics themselves were correct.** Mean, sample variance, skewness, kurtosis, R-7 percentiles, scaled MAD, geometric mean, autocorrelation, EMA, and symmetry all matched an independent implementation to full precision, and the mode algorithm survived 200,000 randomized cases. Nothing in the calculation core changed.

Everything fixed here is input handling, output formatting, flag validation, or test quality. Most of these produce silently wrong or silently missing output, which is worse than an error.

## Bugs fixed

- **NaN and infinities were accepted as data.** `ParseFloat` parses them, and one line poisoned everything downstream — output could read `Min: NaN` alongside `Max: 4`. Now rejected and counted as skipped lines.
- **Small numbers collapsed to zero.** Fixed 4-decimal formatting turned `{0.00004, 0.00006}` into `Min: 0, Max: 0.0001, Mean: 0.0001`. Decimal width now scales with magnitude; still no scientific notation.
- **`-k` had no validation** — the only unchecked numeric flag. `-k -1` reported every data point as an outlier.
- **Options after the filename were silently ignored.** Go's `flag` stops at the first non-flag token, so `stats data.txt -z 2.0` produced no Z-outliers and no warning. Now an error.
- **`-z` on zero-variance data dropped both outlier lines entirely** — no output at all, not even the `N/A` already given to the zero-MAD case.
- **The `-T` star convention was misleading, so it is gone.** Min, Max, Q1, Q3, and IQR were unstarred, yet Min and Max are the trim boundaries themselves. The header and footnote already say everything comes from the trimmed data.
- **The sorted-input warning omitted EMA**, which is order-dependent — on ascending `1..10` with `-e 3` it returns essentially the maximum.
- **Histogram bins were not capped to the observation count** while trendline bins were, so `-b 20` on 7 values misaligned the two lines.
- **Bins holding one value rendered identically to empty bins** (integer division gave level 0).

Also: `-v` is now handled before flag validation, so `stats -v -b 3` prints the version.

## New features

**95% confidence interval** for the mean (`mean ± 1.96 × SE`), suppressed when n < 2. Documented as the normal approximation, slightly narrow for small samples.

**Modal bin fallback.** The mode requires exactly equal values, which is near-useless for continuous data. When nothing repeats, the line reads `None (modal bin: 6-67.75, 4 values)`. The README notes this depends on the chosen binning.

**`-j` JSON output.** Outlier arrays use a two-state convention: `[]` means the detector ran and found nothing, `null` means it never ran. Guard flags mark values that are meaningless rather than zero.

## Testing

**Nothing was running the tests.** The only workflow was a release-on-tag GoReleaser job — `verify_stats.sh` even carried a comment about a GitHub Actions requirement for a job that did not exist. There is now a test job on every push and PR running vet, gofmt, `go test`, and both verifiers, with the release gated behind it.

`stats_test.go` goes from ~90 to 162 tests. `TestTrimDatasetTooSmall` was a tautology that recomputed the trim arithmetic inside the test and never called the program. Custom percentiles had zero coverage despite `-p` shipping long ago. CLI tests now compile the package once in `TestMain` instead of `go run stats.go`, which would break if the program is ever split across files.

`verify_stats.sh` now reads `-j` output through `jq`, replacing ~20 lines of fragile scraping. Three `FAIL` branches were unreachable dead code — they assigned from a pipeline ending in bare `grep`, so under `set -e` a regression aborted the script instead of reporting it.

`verify_stats.py` is new: a pure standard-library reimplementation compared field by field against the JSON across eleven datasets, over 700 comparisons, reaching the glyph strings, symmetry, modal bin, and flag rejection messages that are impractical in bc.

One note: block glyphs are compared with a one-level tolerance. The verifier initially flagged a trendline mismatch under `-l` that turned out to be a genuine tie, not a bug — that chunk's average lands exactly on the data midpoint, making `normalized × 7` exactly 3.5, where a one-ulp difference between Go's and Python's `log()` flips the block. Two-level differences still fail.

## Documentation

All three worked examples regenerated. `Sum` and `-v` documented for the first time — `Sum` prints on every run and appeared nowhere in the docs. Two things that will bite anyone cross-checking results are now stated plainly: percentiles use **R-7** (disagreeing with Excel's `PERCENTILE.EXC`, most SQL engines, and Prometheus), and variance is the **sample** form, which biases the standard error, CI, CV, and Z-outliers if your input is a whole population.

`.gitignore` now covers the compiled `stats` binary, previously untracked but not ignored and one `git add .` from committing 1.8 MB.

## Verification

```
gofmt -l .        clean
go vet ./...      clean
go test ./...     162 tests, all passing
./verify_stats.sh 29 bc comparisons + structural checks, all passing
./verify_stats.py 713 comparisons, all passing
```
